### PR TITLE
refactor mpt_issuance_id into SLE::getJson

### DIFF
--- a/src/libxrpl/protocol/STLedgerEntry.cpp
+++ b/src/libxrpl/protocol/STLedgerEntry.cpp
@@ -125,6 +125,10 @@ STLedgerEntry::getJson(JsonOptions options) const
 
     ret[jss::index] = to_string(key_);
 
+    if (getType() == ltMPTOKEN_ISSUANCE)
+        ret[jss::mpt_issuance_id] = to_string(
+            makeMptID(getFieldU32(sfSequence), getAccountID(sfIssuer)));
+
     return ret;
 }
 

--- a/src/test/rpc/LedgerRPC_test.cpp
+++ b/src/test/rpc/LedgerRPC_test.cpp
@@ -2394,6 +2394,9 @@ class LedgerRPC_test : public beast::unit_test::suite
             BEAST_EXPECT(
                 jrr[jss::node][sfMPTokenMetadata.jsonName] ==
                 strHex(std::string{"123"}));
+            BEAST_EXPECT(
+                jrr[jss::node][jss::mpt_issuance_id] ==
+                strHex(mptAlice.issuanceID()));
         }
         {
             // Request an index that is not a MPTIssuance.

--- a/src/xrpld/rpc/detail/RPCHelpers.cpp
+++ b/src/xrpld/rpc/detail/RPCHelpers.cpp
@@ -285,13 +285,7 @@ getAccountObjects(
             if (!typeFilter.has_value() ||
                 typeMatchesFilter(typeFilter.value(), sleNode->getType()))
             {
-                auto sleJson = sleNode->getJson(JsonOptions::none);
-                if (sleNode->getType() == ltMPTOKEN_ISSUANCE)
-                    sleJson[jss::mpt_issuance_id] = to_string(makeMptID(
-                        (*sleNode)[sfSequence],
-                        sleNode->getAccountID(sfIssuer)));
-
-                jvObjects.append(sleJson);
+                jvObjects.append(sleNode->getJson(JsonOptions::none));
             }
 
             if (++i == mlimit)

--- a/src/xrpld/rpc/handlers/LedgerData.cpp
+++ b/src/xrpld/rpc/handlers/LedgerData.cpp
@@ -124,10 +124,6 @@ doLedgerData(RPC::JsonContext& context)
                 Json::Value& entry =
                     nodes.append(sle->getJson(JsonOptions::none));
                 entry[jss::index] = to_string(sle->key());
-
-                if (sle->getType() == ltMPTOKEN_ISSUANCE)
-                    entry[jss::mpt_issuance_id] = to_string(makeMptID(
-                        (*sle)[sfSequence], sle->getAccountID(sfIssuer)));
             }
         }
     }

--- a/src/xrpld/rpc/handlers/LedgerEntry.cpp
+++ b/src/xrpld/rpc/handlers/LedgerEntry.cpp
@@ -774,7 +774,12 @@ doLedgerEntry(RPC::JsonContext& context)
         }
         else
         {
-            jvResult[jss::node] = sleNode->getJson(JsonOptions::none);
+            auto sleJson = sleNode->getJson(JsonOptions::none);
+            if (sleNode->getType() == ltMPTOKEN_ISSUANCE)
+                sleJson[jss::mpt_issuance_id] = to_string(makeMptID(
+                    (*sleNode)[sfSequence], sleNode->getAccountID(sfIssuer)));
+
+            jvResult[jss::node] = sleJson;
             jvResult[jss::index] = to_string(uNodeIndex);
         }
     }

--- a/src/xrpld/rpc/handlers/LedgerEntry.cpp
+++ b/src/xrpld/rpc/handlers/LedgerEntry.cpp
@@ -774,12 +774,7 @@ doLedgerEntry(RPC::JsonContext& context)
         }
         else
         {
-            auto sleJson = sleNode->getJson(JsonOptions::none);
-            if (sleNode->getType() == ltMPTOKEN_ISSUANCE)
-                sleJson[jss::mpt_issuance_id] = to_string(makeMptID(
-                    (*sleNode)[sfSequence], sleNode->getAccountID(sfIssuer)));
-
-            jvResult[jss::node] = sleJson;
+            jvResult[jss::node] = sleNode->getJson(JsonOptions::none);
             jvResult[jss::index] = to_string(uNodeIndex);
         }
     }


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

Missing mpt_issuance_id in `ledger_entry` response if the object type is `MPTokenIssuance`. Although not necessary (since the user probably already knows the mpt id in their request), we still should make things consistent by injecting the id into the response if it's a MPTokenIssuance object.
<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
