### PR TITLE
Simplify checkMPTDEX() and checkMPTTx().

### DIFF
--- a/include/xrpl/ledger/View.h
+++ b/include/xrpl/ledger/View.h
@@ -1101,6 +1101,12 @@ enforceMPTokenAuthorization(
     XRPAmount const& priorBalance,
     beast::Journal j);
 
+/** Check if Asset can be traded on DEX. return tecNO_PERMISSION
+ * if it doesn't and tesSUCCESS otherwise.
+ */
+[[nodiscard]] TER
+canTrade(ReadView const& view, Asset const& asset);
+
 /** Check if the destination account is allowed
  *  to receive MPT. Return tecNO_AUTH if it doesn't
  *  and tesSUCCESS otherwise.

--- a/include/xrpl/protocol/TER.h
+++ b/include/xrpl/protocol/TER.h
@@ -210,6 +210,7 @@ enum TERcodes : TERUnderlyingType {
     terADDRESS_COLLISION,       // Failed to allocate AccountID when trying to
                                 // create a pseudo-account
     terNO_DELEGATE_PERMISSION,  // Delegate does not have permission
+    terLOCKED,                  // MPT is locked
 };
 
 //------------------------------------------------------------------------------

--- a/src/libxrpl/ledger/View.cpp
+++ b/src/libxrpl/ledger/View.cpp
@@ -3442,6 +3442,22 @@ enforceMPTokenAuthorization(
 }
 
 TER
+canTrade(ReadView const& view, Asset const& asset)
+{
+    return asset.visit(
+        [&](Issue const&) -> TER { return tesSUCCESS; },
+        [&](MPTIssue const& mptIssue) -> TER {
+            auto const sleIssuance =
+                view.read(keylet::mptIssuance(mptIssue.getMptID()));
+            if (!sleIssuance)
+                return tecOBJECT_NOT_FOUND;
+            if (!sleIssuance->isFlag(lsfMPTCanTrade))
+                return tecNO_PERMISSION;
+            return tesSUCCESS;
+        });
+}
+
+TER
 canTransfer(
     ReadView const& view,
     MPTIssue const& mptIssue,

--- a/src/test/app/AMMClawbackMPT_test.cpp
+++ b/src/test/app/AMMClawbackMPT_test.cpp
@@ -34,7 +34,7 @@ class AMMClawbackMPT_test : public beast::unit_test::suite
                  .issuer = gw,
                  .holders = {alice},
                  .pay = 40'000,
-                 .flags = tfMPTCanClawback});
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
 
             auto const USD = gw["USD"];
             env.trust(USD(10000), alice);
@@ -174,7 +174,7 @@ class AMMClawbackMPT_test : public beast::unit_test::suite
                  .issuer = gw2,
                  .holders = {alice},
                  .pay = 40'000,
-                 .flags = tfMPTCanClawback | tfMPTCanTransfer});
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
 
             AMM amm(env, alice, BTC(100), USD(100));
             env.close();
@@ -204,7 +204,7 @@ class AMMClawbackMPT_test : public beast::unit_test::suite
                  .issuer = gw,
                  .holders = {alice},
                  .pay = 40'000,
-                 .flags = tfMPTCanClawback | tfMPTCanTransfer});
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
 
             AMM amm(env, alice, BTC(100), XRP(100));
             env.close();
@@ -232,7 +232,7 @@ class AMMClawbackMPT_test : public beast::unit_test::suite
              .issuer = gw,
              .holders = {alice},
              .pay = 10'000,
-             .flags = tfMPTCanClawback | tfMPTCanTransfer});
+             .flags = tfMPTCanClawback | MPTDEXFlags});
 
         AMM amm(env, alice, XRP(1'000), BTC(1'000));
 
@@ -280,7 +280,7 @@ class AMMClawbackMPT_test : public beast::unit_test::suite
                  .issuer = gw2,
                  .holders = {alice},
                  .pay = 40'000'000000,
-                 .flags = tfMPTCanClawback | tfMPTCanTransfer});
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
 
             AMM amm(env, alice, BTC(1000000000), USD(2000));
             env.close();
@@ -346,7 +346,7 @@ class AMMClawbackMPT_test : public beast::unit_test::suite
                  .issuer = gw,
                  .holders = {alice, bob},
                  .pay = 40'000'000000,
-                 .flags = tfMPTCanClawback | tfMPTCanTransfer});
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
 
             AMM amm(env, alice, BTC(1000000000), XRP(2000));
             env.close();
@@ -456,14 +456,14 @@ class AMMClawbackMPT_test : public beast::unit_test::suite
                  .issuer = gw,
                  .holders = {alice, bob},
                  .pay = 40'000'000000,
-                 .flags = tfMPTCanClawback | tfMPTCanTransfer});
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
 
             MPT ETH = MPTTester(
                 {.env = env,
                  .issuer = gw2,
                  .holders = {alice, bob},
                  .pay = 30'000'000000,
-                 .flags = tfMPTCanClawback | tfMPTCanTransfer});
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
 
             AMM amm(env, alice, BTC(2'000'000000), ETH(3'000'000000));
             env.close();
@@ -574,7 +574,7 @@ class AMMClawbackMPT_test : public beast::unit_test::suite
                  .issuer = gw2,
                  .holders = {alice, bob},
                  .pay = 40'000'000000,
-                 .flags = tfMPTCanClawback | tfMPTCanTransfer});
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
 
             AMM amm(env, alice, BTC(2000000000), USD(2000));
             env.close();
@@ -631,7 +631,7 @@ class AMMClawbackMPT_test : public beast::unit_test::suite
                  .issuer = gw,
                  .holders = {alice, bob},
                  .pay = 40'000'000000,
-                 .flags = tfMPTCanClawback | tfMPTCanTransfer});
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
 
             AMM amm(env, alice, BTC(5000), XRP(10'000));
             env.close();
@@ -688,14 +688,14 @@ class AMMClawbackMPT_test : public beast::unit_test::suite
                  .issuer = gw,
                  .holders = {alice, bob},
                  .pay = 40'000'000000,
-                 .flags = tfMPTCanClawback | tfMPTCanTransfer});
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
 
             MPT ETH = MPTTester(
                 {.env = env,
                  .issuer = gw2,
                  .holders = {alice, bob},
                  .pay = 30'000'000000,
-                 .flags = tfMPTCanClawback | tfMPTCanTransfer});
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
 
             AMM amm(env, alice, BTC(20'000), ETH(50'000));
             env.close();
@@ -765,7 +765,7 @@ class AMMClawbackMPT_test : public beast::unit_test::suite
                  .issuer = gw,
                  .holders = {alice, bob},
                  .pay = 40'000'000000,
-                 .flags = tfMPTCanClawback | tfMPTCanTransfer});
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
 
             AMM amm(env, alice, BTC(1'000'000000), USD(2000));
             env.close();
@@ -863,14 +863,14 @@ class AMMClawbackMPT_test : public beast::unit_test::suite
                  .issuer = gw,
                  .holders = {alice, bob},
                  .pay = 40'000'000000,
-                 .flags = tfMPTCanClawback | tfMPTCanTransfer});
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
 
             MPT ETH = MPTTester(
                 {.env = env,
                  .issuer = gw,
                  .holders = {alice, bob},
                  .pay = 30'000'000000,
-                 .flags = tfMPTCanClawback | tfMPTCanTransfer});
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
 
             AMM amm(env, alice, BTC(2'000'000000), ETH(3'000'000000));
             env.close();
@@ -983,7 +983,7 @@ class AMMClawbackMPT_test : public beast::unit_test::suite
                  .issuer = gw,
                  .holders = {alice, bob},
                  .pay = 40'000'000000,
-                 .flags = tfMPTCanClawback | tfMPTCanTransfer});
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
 
             AMM amm(env, alice, BTC(2'000'000000), USD(8'000));
             env.close();
@@ -1042,14 +1042,14 @@ class AMMClawbackMPT_test : public beast::unit_test::suite
                  .issuer = gw,
                  .holders = {alice, bob},
                  .pay = 40'000'000000,
-                 .flags = tfMPTCanClawback | tfMPTCanTransfer});
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
 
             MPT ETH = MPTTester(
                 {.env = env,
                  .issuer = gw,
                  .holders = {alice, bob},
                  .pay = 30'000'000000,
-                 .flags = tfMPTCanClawback | tfMPTCanTransfer});
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
 
             AMM amm(env, alice, BTC(20'000), ETH(10'000));
             env.close();
@@ -1123,7 +1123,7 @@ class AMMClawbackMPT_test : public beast::unit_test::suite
                  .issuer = gw2,
                  .holders = {alice, gw},
                  .pay = 40'000'000000,
-                 .flags = tfMPTCanClawback | tfMPTCanTransfer});
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
 
             AMM amm(env, gw, USD(1000), BTC(2000));
             env.close();
@@ -1224,14 +1224,14 @@ class AMMClawbackMPT_test : public beast::unit_test::suite
                  .issuer = gw,
                  .holders = {gw2, alice},
                  .pay = 40'000'000000,
-                 .flags = tfMPTCanClawback | tfMPTCanTransfer});
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
 
             MPT ETH = MPTTester(
                 {.env = env,
                  .issuer = gw2,
                  .holders = {gw, alice},
                  .pay = 30'000'000000,
-                 .flags = tfMPTCanClawback | tfMPTCanTransfer});
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
 
             AMM amm(env, gw, BTC(10'000), ETH(50'000));
             env.close();
@@ -1454,7 +1454,7 @@ class AMMClawbackMPT_test : public beast::unit_test::suite
                  .issuer = gw,
                  .holders = {alice},
                  .pay = 40'000'000000,
-                 .flags = tfMPTCanClawback | tfMPTCanTransfer});
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
 
             // gw creates AMM pool of BTC/XRP.
             AMM amm(env, gw, XRP(100), BTC(400), ter(tesSUCCESS));
@@ -1504,7 +1504,7 @@ class AMMClawbackMPT_test : public beast::unit_test::suite
                  .issuer = gw,
                  .holders = {alice},
                  .pay = 40'000'000000,
-                 .flags = tfMPTCanClawback | tfMPTCanTransfer});
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
 
             // gw creates AMM pool of BTC/USD.
             AMM amm(env, gw, USD(100), BTC(400), ter(tesSUCCESS));
@@ -1557,14 +1557,14 @@ class AMMClawbackMPT_test : public beast::unit_test::suite
                  .issuer = gw,
                  .holders = {alice},
                  .pay = 40'000'000000,
-                 .flags = tfMPTCanClawback | tfMPTCanTransfer});
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
 
             MPT BTC = MPTTester(
                 {.env = env,
                  .issuer = gw,
                  .holders = {alice},
                  .pay = 40'000'000000,
-                 .flags = tfMPTCanClawback | tfMPTCanTransfer});
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
 
             // gw creates AMM pool of BTC/USD.
             AMM amm(env, gw, USD(100), BTC(400), ter(tesSUCCESS));
@@ -1630,7 +1630,7 @@ class AMMClawbackMPT_test : public beast::unit_test::suite
                  .issuer = gw,
                  .holders = {alice, bob},
                  .pay = 40'000'000000,
-                 .flags = tfMPTCanClawback | tfMPTCanTransfer});
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
 
             AMM amm(env, alice, USD(2), EUR(1));
             amm.deposit(alice, IOUAmount{1'576123487565916, -15});
@@ -1706,14 +1706,14 @@ class AMMClawbackMPT_test : public beast::unit_test::suite
                  .issuer = gw,
                  .holders = {alice, bob},
                  .pay = 40'000'000000,
-                 .flags = tfMPTCanClawback | tfMPTCanTransfer});
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
 
             MPT EUR = MPTTester(
                 {.env = env,
                  .issuer = gw,
                  .holders = {alice, bob},
                  .pay = 40'000'000000,
-                 .flags = tfMPTCanClawback | tfMPTCanTransfer});
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
 
             AMM amm(env, alice, USD(2), EUR(1));
             amm.deposit(alice, IOUAmount{1'576123487565916, -15});
@@ -1837,7 +1837,7 @@ class AMMClawbackMPT_test : public beast::unit_test::suite
                  .issuer = gw,
                  .holders = {alice},
                  .pay = 40'000,
-                 .flags = tfMPTCanClawback | tfMPTCanTransfer});
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
 
             // Asset USD is not clawable without asfAllowTrustLineClawback.
             AMM amm(env, alice, USD(200), BTC(100));
@@ -1845,7 +1845,7 @@ class AMMClawbackMPT_test : public beast::unit_test::suite
                 ter(tecNO_PERMISSION));
 
             // Although BTC is clawable with tfMPTCanClawback.
-            // When tfClawTwoAssets is set, we will claw Asser2 as well.
+            // When tfClawTwoAssets is set, we will claw Asset2 as well.
             // But Asset2 is not clawable. asfAllowTrustLineClawback was not set
             // by the issuer.
             env(amm::ammClawback(gw, alice, BTC, USD, std::nullopt),
@@ -1878,7 +1878,7 @@ class AMMClawbackMPT_test : public beast::unit_test::suite
                  .issuer = gw2,
                  .holders = {alice},
                  .pay = 40'000,
-                 .flags = tfMPTCanClawback | tfMPTCanTransfer});
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
 
             AMM amm(env, alice, USD(200), BTC(100));
 

--- a/src/test/app/AMMExtendedMPT_test.cpp
+++ b/src/test/app/AMMExtendedMPT_test.cpp
@@ -3360,25 +3360,24 @@ private:
         BTC.set({.holder = bob, .flags = tfMPTLock});
 
         {
-            // different from IOU.
-            // with MPT locked,
-            // can not buy more assets
-            env(offer(bob, BTC(5), XRP(25)), ter(tecLOCKED));
+            // different from IOU. The offer is created but not crossed.
+            env(offer(bob, BTC(5), XRP(25)));
             env.close();
+            BEAST_EXPECT(expectOffers(env, bob, 1, {{{BTC(5), XRP(25)}}}));
             BEAST_EXPECT(
                 ammAlice.expectBalances(XRP(500), BTC(105), ammAlice.tokens()));
         }
 
         {
             // can not sell assets
-            env(offer(bob, XRP(1), BTC(5)), ter(tecLOCKED));
+            env(offer(bob, XRP(1), BTC(5)), ter(tecUNFUNDED_OFFER));
 
             // different from IOU
             // can not receive Payment when locked
-            env(pay(alice, bob, BTC(1)), ter(tecLOCKED));
+            env(pay(alice, bob, BTC(1)), ter(tecPATH_DRY));
 
             // can not make Payment when locked
-            env(pay(bob, alice, BTC(1)), ter(tecLOCKED));
+            env(pay(bob, alice, BTC(1)), ter(tecPATH_DRY));
 
             env.require(balance(bob, BTC(10)));
         }
@@ -3474,8 +3473,8 @@ private:
             env(pay(G1, A2, BTC(1)));
             env(pay(A2, G1, BTC(1)));
             // locked
-            env(pay(A2, A1, BTC(1)), ter(tecLOCKED));
-            env(pay(A1, A2, BTC(1)), ter(tecLOCKED));
+            env(pay(A2, A1, BTC(1)), ter(tecPATH_DRY));
+            env(pay(A1, A2, BTC(1)), ter(tecPATH_DRY));
         }
 
         {

--- a/src/test/app/AMMMPT_test.cpp
+++ b/src/test/app/AMMMPT_test.cpp
@@ -306,7 +306,7 @@ private:
             },
             {{AMMMPT(20'000), AMMMPT(10'000)}});
 
-        // MPTRequireAuth flag is set and AMM creator is not authorzied
+        // MPTRequireAuth flag is set and AMM creator is not authorized
         {
             Env env{*this};
             env.fund(XRP(30'000), gw, alice);
@@ -326,7 +326,7 @@ private:
             BEAST_EXPECT(!ammAlice.ammExists());
         }
 
-        // MPTLocked flag is set and AMM creator is not the issuer of MPT
+        // MPTLocked flag is set
         {
             Env env{*this};
             fund(env, gw, {alice}, {USD(20'000)}, Fund::All);
@@ -4717,12 +4717,12 @@ private:
                 path(~static_cast<MPT>(BTC)),
                 txflags(tfPartialPayment | tfNoRippleDirect),
                 sendmax(XRP(10)),
-                ter(tecLOCKED));
+                ter(tecPATH_DRY));
             env(pay(alice, carol, XRP(1)),
                 path(~XRP),
                 txflags(tfPartialPayment | tfNoRippleDirect),
                 sendmax(BTC(10)),
-                ter(tecLOCKED));
+                ter(tecPATH_DRY));
         }
 
         // Individually locked MPT destination account.
@@ -4743,7 +4743,7 @@ private:
                 path(~static_cast<MPT>(BTC)),
                 txflags(tfPartialPayment | tfNoRippleDirect),
                 sendmax(XRP(10)),
-                ter(tecLOCKED));
+                ter(tecPATH_DRY));
         }
 
         // Individually locked MPT source account
@@ -4764,7 +4764,7 @@ private:
                 path(~XRP),
                 txflags(tfPartialPayment | tfNoRippleDirect),
                 sendmax(BTC(10)),
-                ter(tecLOCKED));
+                ter(tecPATH_DRY));
         }
 
         // lock on both sides
@@ -4794,13 +4794,13 @@ private:
                 path(~MPT(ETH)),
                 txflags(tfPartialPayment | tfNoRippleDirect),
                 sendmax(BTC(10)),
-                ter(tecLOCKED));
+                ter(tecPATH_DRY));
 
             env(pay(alice, carol, BTC(1)),
                 path(~MPT(BTC)),
                 txflags(tfPartialPayment | tfNoRippleDirect),
                 sendmax(ETH(10)),
-                ter(tecLOCKED));
+                ter(tecPATH_DRY));
         }
 
         // Individually locked AMM MPT
@@ -7509,7 +7509,7 @@ private:
              .issuer = gw,
              .holders = {alice, bob},
              .pay = 40'000'000000,
-             .flags = tfMPTCanClawback | tfMPTCanLock | tfMPTCanTransfer});
+             .flags = tfMPTCanClawback | tfMPTCanLock | MPTDEXFlags});
 
         AMM amm(env, alice, BTC(2), USD(1));
         amm.deposit(alice, IOUAmount{1'876123487565916, -15});

--- a/src/test/app/AMMMPT_test.cpp
+++ b/src/test/app/AMMMPT_test.cpp
@@ -136,7 +136,7 @@ private:
                 env, alice, BTC(20'000), BTC(10'000), ter(temBAD_AMM_TOKENS));
         }
 
-        // MPTCanTransfer is not set and AMM creator is not the issuer of MPT
+        // MPTCanTrade is not set and AMM creator is not the issuer of MPT
         {
             Env env{*this};
             env.fund(XRP(30'000), alice, gw);

--- a/src/test/app/AMM_test.cpp
+++ b/src/test/app/AMM_test.cpp
@@ -318,6 +318,8 @@ private:
             env.close();
             AMM ammAlice(env, alice, XRP(10'000), USD(10'000), ter(tecFROZEN));
             BEAST_EXPECT(!ammAlice.ammExists());
+            // issuer can create
+            AMM amm(env, gw, XRP(10'000), USD(10'000));
         }
 
         // Insufficient reserve, XRP/IOU

--- a/src/test/app/AMM_test.cpp
+++ b/src/test/app/AMM_test.cpp
@@ -300,8 +300,11 @@ private:
             env.close();
             env(trust(gw, alice["USD"](30'000)));
             env.close();
-            AMM ammAlice(env, alice, XRP(10'000), USD(10'000), ter(tecFROZEN));
-            BEAST_EXPECT(!ammAlice.ammExists());
+            for (auto const& account : {alice, gw})
+            {
+                AMM amm(env, account, XRP(10'000), USD(10'000), ter(tecFROZEN));
+                BEAST_EXPECT(!amm.ammExists());
+            }
         }
 
         // Individually frozen
@@ -897,26 +900,29 @@ private:
                         std::nullopt,
                         std::nullopt,
                         ter(tecFROZEN));
-                ammAlice.deposit(
-                    carol,
-                    USD(100),
-                    std::nullopt,
-                    std::nullopt,
-                    std::nullopt,
-                    ter(tecFROZEN));
-                ammAlice.deposit(
-                    carol,
-                    1'000'000,
-                    std::nullopt,
-                    std::nullopt,
-                    ter(tecFROZEN));
-                ammAlice.deposit(
-                    carol,
-                    XRP(100),
-                    USD(100),
-                    std::nullopt,
-                    std::nullopt,
-                    ter(tecFROZEN));
+                for (auto const& account : {carol, gw})
+                {
+                    ammAlice.deposit(
+                        account,
+                        USD(100),
+                        std::nullopt,
+                        std::nullopt,
+                        std::nullopt,
+                        ter(tecFROZEN));
+                    ammAlice.deposit(
+                        account,
+                        1'000'000,
+                        std::nullopt,
+                        std::nullopt,
+                        ter(tecFROZEN));
+                    ammAlice.deposit(
+                        account,
+                        XRP(100),
+                        USD(100),
+                        std::nullopt,
+                        std::nullopt,
+                        ter(tecFROZEN));
+                }
             },
             std::nullopt,
             0,
@@ -2066,14 +2072,25 @@ private:
 
         // Globally frozen asset
         testAMM([&](AMM& ammAlice, Env& env) {
+            ammAlice.deposit(
+                {.account = gw,
+                 .asset1In = USD(1'000),
+                 .asset2In = XRP(1'000)});
             env(fset(gw, asfGlobalFreeze));
             env.close();
             // Can withdraw non-frozen token
-            ammAlice.withdraw(alice, XRP(100));
-            ammAlice.withdraw(
-                alice, USD(100), std::nullopt, std::nullopt, ter(tecFROZEN));
-            ammAlice.withdraw(
-                alice, 1'000, std::nullopt, std::nullopt, ter(tecFROZEN));
+            for (auto const& account : {alice, gw})
+            {
+                ammAlice.withdraw(account, XRP(100));
+                ammAlice.withdraw(
+                    account,
+                    USD(100),
+                    std::nullopt,
+                    std::nullopt,
+                    ter(tecFROZEN));
+                ammAlice.withdraw(
+                    account, 1'000, std::nullopt, std::nullopt, ter(tecFROZEN));
+            }
         });
 
         // Individually frozen (AMM) account

--- a/src/test/app/CheckMPT_test.cpp
+++ b/src/test/app/CheckMPT_test.cpp
@@ -69,7 +69,7 @@ class CheckMPT_test : public beast::unit_test::suite
 
         MPT const USD = MPTTester({.env = env, .issuer = gw});
 
-        // Note that no trust line has been set up for alice, but alice can
+        // Note that no MPToken has been set up for alice, but alice can
         // still write a check for USD.  You don't have to have the funds
         // necessary to cover a check in order to write a check.
         auto writeTwoChecks = [&env, &USD, this](
@@ -354,11 +354,11 @@ class CheckMPT_test : public beast::unit_test::suite
             // Note that IOU returns tecPATH_DRY in this case.
             // IOU's internal error is terNO_LINE, which is
             // considered ter re-triable and changed to tecPATH_DRY.
-            env(pay(alice, bob, USD(1)), ter(tecLOCKED));
+            env(pay(alice, bob, USD(1)), ter(tecPATH_DRY));
             env.close();
             env(check::create(bob, alice, USD(50)), ter(tecFROZEN));
             env.close();
-            env(pay(bob, alice, USD(1)), ter(tecLOCKED));
+            env(pay(bob, alice, USD(1)), ter(tecPATH_DRY));
             env.close();
             env(check::create(gw1, alice, USD(50)), ter(tecFROZEN));
             env.close();
@@ -404,7 +404,7 @@ class CheckMPT_test : public beast::unit_test::suite
     void
     testCashMPT(FeatureBitset features)
     {
-        // Explore many of the valid ways to cash a check for an IOU.
+        // Explore many of the valid ways to cash a check for an MPT.
         testcase("Cash MPT");
 
         using namespace test::jtx;
@@ -413,7 +413,7 @@ class CheckMPT_test : public beast::unit_test::suite
         Account const alice{"alice"};
         Account const bob{"bob"};
         {
-            // Simple IOU check cashed with Amount (with failures).
+            // Simple MPT check cashed with Amount (with failures).
             Env env{*this, features};
 
             env.fund(XRP(1'000), gw, alice, bob);
@@ -673,10 +673,6 @@ class CheckMPT_test : public beast::unit_test::suite
             USDM.authorize({.holder = bob});
             env.close();
 
-            // Two possible outcomes here depending on whether cashing a
-            // check can build a trust line:
-            //  o If it can build a trust line, then the check is allowed to
-            //    exceed the trust limit and bob gets the full transfer.
             env(check::cash(bob, chkId, check::DeliverMin(USD(4))));
             STAmount const bobGot = USD(7);
             verifyDeliveredAmount(env, bobGot);

--- a/src/test/app/Check_test.cpp
+++ b/src/test/app/Check_test.cpp
@@ -364,10 +364,16 @@ class Check_test : public beast::unit_test::suite
             env(check::create(alice, bob, USF(50)), ter(tecFROZEN));
             env.close();
 
+            env(check::create(gwF, bob, USF(50)), ter(tecFROZEN));
+            env.close();
+
             env(fclear(gwF, asfGlobalFreeze));
             env.close();
 
             env(check::create(alice, bob, USF(50)));
+            env.close();
+
+            env(check::create(gwF, bob, USF(50)));
             env.close();
         }
         {
@@ -1272,6 +1278,14 @@ class Check_test : public beast::unit_test::suite
         env(check::create(alice, bob, USD(4)));
         env.close();
 
+        uint256 const chkIdFroz4ToIssuer{getCheckIndex(alice, env.seq(alice))};
+        env(check::create(alice, gw, USD(4)));
+        env.close();
+
+        uint256 const chkIdFroz4Issuer{getCheckIndex(gw, env.seq(gw))};
+        env(check::create(gw, alice, USD(4)));
+        env.close();
+
         uint256 const chkIdNoDest1{getCheckIndex(alice, env.seq(alice))};
         env(check::create(alice, bob, USD(1)));
         env.close();
@@ -1399,6 +1413,21 @@ class Check_test : public beast::unit_test::suite
                 ter(tecPATH_PARTIAL));
             env.close();
 
+            env(check::cash(gw, chkIdFroz4ToIssuer, USD(1)),
+                ter(tecPATH_PARTIAL));
+            env.close();
+            env(check::cash(
+                    gw, chkIdFroz4ToIssuer, check::DeliverMin(USD(0.5))),
+                ter(tecPATH_PARTIAL));
+            env.close();
+
+            env(check::cash(alice, chkIdFroz4Issuer, USD(1)), ter(tecFROZEN));
+            env.close();
+            env(check::cash(
+                    alice, chkIdFroz4Issuer, check::DeliverMin(USD(0.5))),
+                ter(tecFROZEN));
+            env.close();
+
             env(fclear(gw, asfGlobalFreeze));
             env.close();
 
@@ -1407,6 +1436,9 @@ class Check_test : public beast::unit_test::suite
             env.close();
             env.require(balance(alice, USD(19)));
             env.require(balance(bob, USD(1)));
+
+            env(check::cash(gw, chkIdFroz4ToIssuer, USD(1)));
+            env.close();
 
             // Freeze individual trustlines.
             env(trust(gw, alice["USD"](0), tfSetFreeze));
@@ -1422,7 +1454,7 @@ class Check_test : public beast::unit_test::suite
             env.close();
             env(check::cash(bob, chkIdFroz2, USD(2)));
             env.close();
-            env.require(balance(alice, USD(17)));
+            env.require(balance(alice, USD(16)));
             env.require(balance(bob, USD(3)));
 
             // Freeze bob's trustline.  bob can't cash the check.
@@ -1439,7 +1471,7 @@ class Check_test : public beast::unit_test::suite
             env.close();
             env(check::cash(bob, chkIdFroz3, check::DeliverMin(USD(1))));
             verifyDeliveredAmount(env, USD(3));
-            env.require(balance(alice, USD(14)));
+            env.require(balance(alice, USD(13)));
             env.require(balance(bob, USD(6)));
 
             // Set bob's freeze bit in the other direction.  Check
@@ -1457,7 +1489,7 @@ class Check_test : public beast::unit_test::suite
             env.close();
             env(check::cash(bob, chkIdFroz4, USD(4)));
             env.close();
-            env.require(balance(alice, USD(10)));
+            env.require(balance(alice, USD(9)));
             env.require(balance(bob, USD(10)));
         }
         {
@@ -1474,7 +1506,7 @@ class Check_test : public beast::unit_test::suite
             // bob can cash a check with a destination tag.
             env(check::cash(bob, chkIdHasDest2, USD(2)));
             env.close();
-            env.require(balance(alice, USD(8)));
+            env.require(balance(alice, USD(7)));
             env.require(balance(bob, USD(12)));
 
             // Clear the RequireDest flag on bob's account so he can
@@ -1483,7 +1515,7 @@ class Check_test : public beast::unit_test::suite
             env.close();
             env(check::cash(bob, chkIdNoDest1, USD(1)));
             env.close();
-            env.require(balance(alice, USD(7)));
+            env.require(balance(alice, USD(6)));
             env.require(balance(bob, USD(13)));
         }
     }

--- a/src/test/app/MPToken_test.cpp
+++ b/src/test/app/MPToken_test.cpp
@@ -3660,20 +3660,25 @@ class MPToken_test : public beast::unit_test::suite
         {
             Env env(*this);
             env.fund(XRP(1'000), gw, alice);
-            MPT const BTC = MPT(gw, 0);
+            env.close();
+            MPT const BTC = MPTTester(
+                {.env = env, .issuer = gw, .holders = {alice}, .pay = 100});
             MPT const ETH = MPT(gw, 1);
 
-            env(offer(alice, ETH(10), BTC(10)), ter(tecUNFUNDED_OFFER));
+            env(offer(alice, ETH(10), BTC(10)), ter(tecOBJECT_NOT_FOUND));
+            env(offer(alice, BTC(10), ETH(10)), ter(tecUNFUNDED_OFFER));
         }
 
         // MPToken object doesn't exist and the account is not the issuer of MPT
         {
             Env env(*this);
             env.fund(XRP(1'000), gw, alice);
-            MPTTester BTC({.env = env, .issuer = gw});
+            MPTTester BTC(
+                {.env = env, .issuer = gw, .holders = {alice}, .pay = 100});
             MPTTester ETH({.env = env, .issuer = gw});
 
-            env(offer(alice, ETH(10), BTC(10)), ter(tecUNFUNDED_OFFER));
+            env(offer(alice, ETH(10), BTC(10)));
+            env(offer(alice, BTC(10), ETH(10)), ter(tecUNFUNDED_OFFER));
         }
 
         // MPTLock flag is set and the account is not the issuer of MPT
@@ -3758,32 +3763,66 @@ class MPToken_test : public beast::unit_test::suite
         // MPTCanTransfer is not set and the account is not the issuer of MPT
         {
             Env env(*this);
-            env.fund(XRP(1'000), gw, alice);
+            env.fund(XRP(1'000), gw, alice, carol);
             MPTTester BTC(
                 {.env = env,
                  .issuer = gw,
-                 .holders = {alice},
+                 .holders = {alice, carol},
                  .pay = 100,
                  .flags = tfMPTCanTrade,
                  .mutableFlags = tmfMPTCanMutateCanTransfer});
             MPTTester ETH(
                 {.env = env,
                  .issuer = gw,
-                 .holders = {alice},
+                 .holders = {alice, carol},
                  .pay = 100,
                  .flags = tfMPTCanTrade | tfMPTCanTransfer,
                  .mutableFlags = tmfMPTCanMutateCanTransfer});
 
             // Can create
-            env(offer(alice, ETH(10), BTC(10)), ter(tesSUCCESS));
+            env(offer(alice, ETH(10), BTC(10)), txflags(tfPassive));
             BTC.set({.mutableFlags = tmfMPTSetCanTransfer});
             ETH.set({.mutableFlags = tmfMPTClearCanTransfer});
-            env(offer(alice, ETH(10), BTC(10)), ter(tesSUCCESS));
+            env(offer(alice, ETH(10), BTC(10)), txflags(tfPassive));
             BEAST_EXPECT(getAccountOffers(env, alice)[jss::offers].size() == 2);
 
             // issuer can create
+            env(offer(gw, ETH(10), BTC(10)), txflags(tfPassive));
+            env.close();
 
-            env(offer(gw, ETH(10), BTC(10)));
+            // can cross issuer's offer, other offers are removed
+            env(offer(carol, BTC(10), ETH(10)));
+            BEAST_EXPECT(expectOffers(env, alice, 0));
+            BEAST_EXPECT(expectOffers(env, gw, 0));
+            BEAST_EXPECT(expectOffers(env, carol, 0));
+            // can't cross holder's offer, holder's offer is removed
+            env(offer(alice, ETH(10), BTC(10)), txflags(tfPassive));
+            env(offer(carol, BTC(10), ETH(10)));
+            BEAST_EXPECT(expectOffers(env, alice, 0));
+            BEAST_EXPECT(expectOffers(env, carol, 1));
+        }
+
+        // MPTCanTrade is disabled
+        {
+            Env env(*this);
+            env.fund(XRP(1'000), gw, alice, carol);
+            MPTTester BTC(
+                {.env = env,
+                 .issuer = gw,
+                 .holders = {alice, carol},
+                 .pay = 100,
+                 .flags = tfMPTCanTransfer,
+                 .mutableFlags = tmfMPTCanMutateCanTrade});
+            MPTTester ETH(
+                {.env = env,
+                 .issuer = gw,
+                 .holders = {alice, carol},
+                 .pay = 100,
+                 .flags = tfMPTCanTrade,
+                 .mutableFlags = tmfMPTCanMutateCanTrade});
+
+            // Can't create
+            env(offer(gw, ETH(10), BTC(10)), ter(tecNO_PERMISSION));
             env.close();
         }
 
@@ -4068,11 +4107,18 @@ class MPToken_test : public beast::unit_test::suite
                 sendmax(ETH(10)),
                 ter(tecOBJECT_NOT_FOUND));
             env.close();
+            env(pay(alice, carol, ETH(10)),
+                sendmax(MPT(gw)(10)),
+                ter(tecOBJECT_NOT_FOUND));
+            env.close();
 
             // MPToken object doesn't exist
 
+            // holder and issuer fail
             env(pay(ed, carol, BTC(10)), sendmax(ETH(10)), ter(tecNO_AUTH));
             env(pay(carol, ed, BTC(10)), sendmax(ETH(10)), ter(tecNO_AUTH));
+            env(pay(ed, gw, BTC(10)), sendmax(ETH(10)), ter(tecNO_AUTH));
+            env(pay(gw, ed, BTC(10)), sendmax(ETH(10)), ter(tecNO_AUTH));
             env.close();
 
             // MPTRequireAuth is set
@@ -4113,7 +4159,7 @@ class MPToken_test : public beast::unit_test::suite
 
             // MPTCanTransfer is not set
 
-            // Fail regardless if source/destinaiton is the issuer or
+            // Fail regardless if source/destination is the issuer or
             // not since the offer is owned by a holder.
             BTC.set({.mutableFlags = tmfMPTClearCanTransfer});
             env(pay(ed, carol, BTC(10)),
@@ -4157,6 +4203,7 @@ class MPToken_test : public beast::unit_test::suite
             env.close();
             env(offer(gw, BTC(100), ETH(100)), txflags(tfPassive));
             env.close();
+            BEAST_EXPECT(expectOffers(env, bob, 2));
             env(pay(ed, carol, BTC(10)),
                 path(~BTC),
                 sendmax(ETH(10)),
@@ -4209,13 +4256,13 @@ class MPToken_test : public beast::unit_test::suite
                  .mutableFlags = tmfMPTCanMutateCanTransfer});
             // takerGets can transfer if:
             //  - CanTransfer is set
-            //  - Offer's owner is an issuer
+            //  - The offer's owner is the issuer
             //  - BookStep is the last step, which means strand's destination is
-            //    an issuer
+            //    the issuer
             // takerPays can transfer if
             //  - BookStep is the first step, which means strand's source is
-            //    an issuer
-            //  - Offer's owner is an issuer
+            //    the issuer
+            //  - The offer's owner is the issuer
             //  - Previous step is BookStep, which transfers per above
             //  - CanTransfer is set
             env(offer(bob, CAD(100), USD(100)), txflags(tfPassive));
@@ -4303,59 +4350,120 @@ class MPToken_test : public beast::unit_test::suite
             BEAST_EXPECT(expectOffers(env, gw, 0));
         }
 
-        // Holders are locked
+        // MPTCanTrade is not set
         {
-            Env env(*this);
+            Env env{*this, features};
             env.fund(XRP(1'000), gw, alice, carol, bob);
+            env.close();
             MPTTester BTC(
                 {.env = env,
                  .issuer = gw,
                  .holders = {alice, carol, bob},
-                 .pay = 100,
-                 .flags = tfMPTCanLock | MPTDEXFlags});
+                 .pay = 1'000,
+                 .flags = tfMPTCanTransfer,
+                 .mutableFlags = tmfMPTCanMutateCanTrade});
             MPTTester ETH(
                 {.env = env,
                  .issuer = gw,
                  .holders = {alice, carol, bob},
-                 .pay = 100,
-                 .flags = tfMPTCanLock | MPTDEXFlags});
+                 .pay = 1'000,
+                 .flags = tfMPTCanTransfer | tfMPTCanTrade,
+                 .mutableFlags = tmfMPTCanMutateCanTrade});
+            MPTTester USD(
+                {.env = env,
+                 .issuer = gw,
+                 .holders = {alice, carol, bob},
+                 .pay = 1'000,
+                 .flags = tfMPTCanTransfer | tfMPTCanTrade,
+                 .mutableFlags = tmfMPTCanMutateCanTrade});
 
-            env(offer(bob, ETH(10), BTC(10)), txflags(tfPassive));
-            env(offer(bob, BTC(10), ETH(10)), txflags(tfPassive));
+            env(pay(alice, carol, ETH(1)),
+                path(~ETH),
+                sendmax(BTC(1)),
+                ter(tecNO_PERMISSION));
+            env(pay(alice, carol, BTC(1)),
+                path(~BTC),
+                sendmax(ETH(1)),
+                ter(tecNO_PERMISSION));
+            env.close();
 
-            auto test = [&](auto const& flag, auto const& err) {
-                BTC.set({.holder = carol, .flags = flag});
-                BTC.set({.holder = alice, .flags = flag});
-                ETH.set({.holder = carol, .flags = flag});
-                ETH.set({.holder = alice, .flags = flag});
+            BTC.set({.mutableFlags = tmfMPTSetCanTrade});
+            env(offer(bob, XRP(1), BTC(1)));
+            env(offer(bob, BTC(1), ETH(1)));
+            env(offer(bob, ETH(1), USD(1)));
+            env.close();
+            BTC.set({.mutableFlags = tmfMPTClearCanTrade});
+            env(pay(gw, carol, USD(1)),
+                path(~BTC, ~ETH, ~USD),
+                sendmax(XRP(1)),
+                ter(tecPATH_PARTIAL));
+            env.close();
+            BEAST_EXPECT(expectOffers(env, bob, 3));
+        }
 
-                env(pay(alice, carol, ETH(1)),
-                    path(~(MPT)ETH),
-                    txflags(tfNoRippleDirect),
-                    sendmax(BTC(1)),
-                    err);
+        // Holders are locked
+        {
+            auto test =
+                [&](auto const& flag, auto const& err, bool globalLock) {
+                    Env env(*this);
+                    env.fund(XRP(1'000), gw, alice, carol, bob);
+                    MPTTester BTC(
+                        {.env = env,
+                         .issuer = gw,
+                         .holders = {alice, carol, bob},
+                         .pay = 100,
+                         .flags = tfMPTCanLock | MPTDEXFlags});
+                    MPTTester ETH(
+                        {.env = env,
+                         .issuer = gw,
+                         .holders = {alice, carol, bob},
+                         .pay = 100,
+                         .flags = tfMPTCanLock | MPTDEXFlags});
 
-                env(pay(alice, carol, BTC(1)),
-                    path(~(MPT)BTC),
-                    txflags(tfNoRippleDirect),
-                    sendmax(ETH(1)),
-                    err);
+                    env(offer(bob, ETH(10), BTC(10)), txflags(tfPassive));
+                    env(offer(bob, BTC(10), ETH(10)), txflags(tfPassive));
 
-                env(pay(gw, carol, ETH(1)),
-                    path(~(MPT)ETH),
-                    txflags(tfNoRippleDirect),
-                    sendmax(BTC(1)),
-                    err);
+                    if (globalLock)
+                    {
+                        BTC.set({.flags = flag});
+                        ETH.set({.flags = flag});
+                    }
+                    else
+                    {
+                        BTC.set({.holder = carol, .flags = flag});
+                        BTC.set({.holder = alice, .flags = flag});
+                        ETH.set({.holder = carol, .flags = flag});
+                        ETH.set({.holder = alice, .flags = flag});
+                    }
 
-                env(pay(alice, gw, BTC(1)),
-                    path(~(MPT)BTC),
-                    txflags(tfNoRippleDirect),
-                    sendmax(ETH(1)),
-                    err);
-            };
+                    env(pay(alice, carol, ETH(1)),
+                        path(~ETH),
+                        txflags(tfNoRippleDirect),
+                        sendmax(BTC(1)),
+                        err);
 
-            test(tfMPTLock, ter(tecPATH_DRY));
-            test(tfMPTUnlock, ter(tesSUCCESS));
+                    env(pay(alice, carol, BTC(1)),
+                        path(~BTC),
+                        txflags(tfNoRippleDirect),
+                        sendmax(ETH(1)),
+                        err);
+
+                    env(pay(gw, carol, ETH(1)),
+                        path(~ETH),
+                        txflags(tfNoRippleDirect),
+                        sendmax(BTC(1)),
+                        err);
+
+                    env(pay(alice, gw, BTC(1)),
+                        path(~BTC),
+                        txflags(tfNoRippleDirect),
+                        sendmax(ETH(1)),
+                        err);
+                };
+
+            test(tfMPTLock, ter(tecPATH_DRY), true);
+            test(tfMPTLock, ter(tecPATH_DRY), false);
+            test(tfMPTUnlock, ter(tesSUCCESS), false);
         }
         {
             Env env(*this);
@@ -5947,6 +6055,10 @@ class MPToken_test : public beast::unit_test::suite
             env(check::create(alice, carol, MPT(gw)(50)),
                 ter(tecOBJECT_NOT_FOUND));
             env.close();
+            auto BTC = MPTTester({.env = env, .issuer = gw});
+            uint256 const chkId{getCheckIndex(gw, env.seq(gw))};
+            env(check::cash(carol, chkId, MPT(gw)(1)), ter(tecNO_ENTRY));
+            env.close();
         }
 
         // MPToken doesn't exist - can create check since MPToken will be
@@ -5996,10 +6108,9 @@ class MPToken_test : public beast::unit_test::suite
 
             mpt.set({.flags = tfMPTLock});
 
-            // Cash Check fails, holder and issuer
-            env(check::cash(carol, chkIdAlice, mpt(1)), ter(tecPATH_PARTIAL));
-            // tec is different if the source is the issuer (this is consistent
-            // with IOU)
+            // Cash Check fails, holder and issuer env(check::cash(carol,
+            // chkIdAlice, mpt(1)), ter(tecPATH_PARTIAL)); // tec is different
+            // if the source is the issuer (this is consistent with IOU)
             env(check::cash(carol, chkIdGw, mpt(2)), ter(tecFROZEN));
             env.close();
 
@@ -6008,6 +6119,32 @@ class MPToken_test : public beast::unit_test::suite
             // Cash Check succeeds, holder and issuer.
             env(check::cash(carol, chkIdAlice, mpt(1)));
             env(check::cash(carol, chkIdGw, mpt(2)));
+
+            // Individual lock
+            mpt.set({.holder = alice, .flags = tfMPTLock});
+            env(check::create(alice, carol, mpt(10)), ter(tecFROZEN));
+            env.close();
+            env(check::create(carol, alice, mpt(10)), ter(tecFROZEN));
+            env.close();
+
+            mpt.set({.holder = alice, .flags = tfMPTUnlock});
+            uint256 const chkId1{getCheckIndex(alice, env.seq(alice))};
+            env(check::create(alice, carol, mpt(10)));
+            env.close();
+            uint256 const chkId2{getCheckIndex(gw, env.seq(gw))};
+            env(check::create(gw, alice, mpt(10)));
+            env.close();
+            uint256 const chkId3{getCheckIndex(alice, env.seq(alice))};
+            env(check::create(alice, gw, mpt(10)));
+            env.close();
+            uint256 const chkId4{getCheckIndex(gw, env.seq(gw))};
+            env(check::create(gw, alice, mpt(10)));
+            env.close();
+            mpt.set({.holder = alice, .flags = tfMPTLock});
+            env(check::cash(carol, chkId1, mpt(1)), ter(tecPATH_PARTIAL));
+            env(check::cash(alice, chkId2, mpt(1)), ter(tecFROZEN));
+            env(check::cash(gw, chkId3, mpt(1)), ter(tecPATH_PARTIAL));
+            env(check::cash(alice, chkId4, mpt(1)), ter(tecFROZEN));
         }
 
         // MPTRequireAuth flag is set and the account is not authorized.
@@ -6094,6 +6231,35 @@ class MPToken_test : public beast::unit_test::suite
             env(pay(gw, alice, mpt(10)));
             env.close();
             env(check::cash(carol, checkId, mpt(10)));
+            env.close();
+        }
+
+        // MPTCanTrade disabled
+        {
+            Env env{*this, features};
+            env.fund(XRP(1'000), gw, alice, carol);
+            env.close();
+
+            MPTTester mpt(
+                {.env = env,
+                 .issuer = gw,
+                 .holders = {alice, carol},
+                 .flags = tfMPTCanTransfer,
+                 .mutableFlags = tmfMPTCanMutateCanTrade});
+
+            uint256 checkId{keylet::check(gw, env.seq(gw)).key};
+
+            // can't create
+            env(check::create(gw, alice, mpt(100)), ter(tecNO_PERMISSION));
+            env.close();
+            mpt.set({.account = gw, .mutableFlags = tmfMPTSetCanTrade});
+
+            // can't cash
+            checkId = keylet::check(gw, env.seq(gw)).key;
+            env(check::create(gw, carol, mpt(100)));
+            env.close();
+            mpt.set({.account = gw, .mutableFlags = tmfMPTClearCanTrade});
+            env(check::cash(carol, checkId, mpt(10)), ter(tecNO_PERMISSION));
             env.close();
         }
 
@@ -6553,7 +6719,8 @@ class MPToken_test : public beast::unit_test::suite
                  .issuer = gw,
                  .flags = tfMPTCanLock | MPTDEXFlags,
                  .mutableFlags = tmfMPTCanMutateRequireAuth |
-                     tmfMPTCanMutateCanTransfer | tmfMPTCanMutateCanClawback});
+                     tmfMPTCanMutateCanTransfer | tmfMPTCanMutateCanClawback |
+                     tmfMPTCanMutateCanTrade});
             auto EUR = MPTTester(
                 {.env = env,
                  .issuer = gw,
@@ -6635,6 +6802,15 @@ class MPToken_test : public beast::unit_test::suite
             // alice can create
             createDeleteAMM(alice);
 
+            // MPTCanTrade is not set
+
+            USD.set({.mutableFlags = tmfMPTSetCanTransfer});
+            USD.set({.mutableFlags = tmfMPTClearCanTrade});
+            // alice and issuer can't create
+            createFail(alice, tecNO_PERMISSION);
+            createFail(gw, tecNO_PERMISSION);
+            USD.set({.mutableFlags = tmfMPTSetCanTrade});
+
             //
             // AMMDeposit
             //
@@ -6706,7 +6882,7 @@ class MPToken_test : public beast::unit_test::suite
             USD.authorize({.account = gw, .holder = carol});
             amm.deposit({.account = carol, .tokens = 1'000});
 
-            // MPTCanTransfer is set
+            // MPTCanTransfer is not set
 
             USD.set({.mutableFlags = tmfMPTClearRequireAuth});
             USD.set({.mutableFlags = tmfMPTClearCanTransfer});
@@ -6726,6 +6902,18 @@ class MPToken_test : public beast::unit_test::suite
             // carol can deposit
             USD.set({.mutableFlags = tmfMPTSetCanTransfer});
             amm.deposit({.account = carol, .tokens = 1'000});
+
+            // MPTCanTrade is not set
+
+            USD.set({.mutableFlags = tmfMPTSetCanTransfer});
+            USD.set({.mutableFlags = tmfMPTClearCanTrade});
+            amm.deposit(
+                {.account = gw, .tokens = 1'000, .err = ter(tecNO_PERMISSION)});
+            amm.deposit(
+                {.account = carol,
+                 .tokens = 1'000,
+                 .err = ter(tecNO_PERMISSION)});
+            USD.set({.mutableFlags = tmfMPTSetCanTrade});
 
             //
             // AMMWithdraw
@@ -6812,6 +7000,16 @@ class MPToken_test : public beast::unit_test::suite
             USD.set({.mutableFlags = tmfMPTSetCanTransfer});
             amm.withdraw(
                 {.account = carol, .asset1Out = USD(1), .asset2Out = EUR(1)});
+
+            USD.set({.mutableFlags = tmfMPTSetCanTransfer});
+            USD.set({.mutableFlags = tmfMPTClearCanTrade});
+            amm.withdraw(
+                {.account = gw, .tokens = 1'000, .err = ter(tecNO_PERMISSION)});
+            amm.withdraw(
+                {.account = carol,
+                 .tokens = 1'000,
+                 .err = ter(tecNO_PERMISSION)});
+            USD.set({.mutableFlags = tmfMPTSetCanTrade});
 
             // MPToken created on withdraw
 

--- a/src/test/app/MPToken_test.cpp
+++ b/src/test/app/MPToken_test.cpp
@@ -16,6 +16,9 @@
 #include <xrpl/protocol/TxFlags.h>
 #include <xrpl/protocol/jss.h>
 
+#include "xrpld/app/misc/AMMHelpers.h"
+#include "xrpld/app/paths/detail/StepChecks.h"
+
 namespace xrpl {
 namespace test {
 
@@ -1412,11 +1415,15 @@ class MPToken_test : public beast::unit_test::suite
             mptAlice.pay(alice, bob, 100);
             mptAlice.pay(alice, carol, 100);
 
+            auto const err = env.current()->rules().enabled(featureMPTokensV2)
+                ? tecPATH_DRY
+                : tecLOCKED;
+
             // Global lock
             mptAlice.set({.account = alice, .flags = tfMPTLock});
             // Can't send between holders
-            mptAlice.pay(bob, carol, 1, tecLOCKED);
-            mptAlice.pay(carol, bob, 2, tecLOCKED);
+            mptAlice.pay(bob, carol, 1, err);
+            mptAlice.pay(carol, bob, 2, err);
             // Issuer can send
             mptAlice.pay(alice, bob, 3);
             // Holder can send back to issuer
@@ -1427,8 +1434,8 @@ class MPToken_test : public beast::unit_test::suite
             // Individual lock
             mptAlice.set({.account = alice, .holder = bob, .flags = tfMPTLock});
             // Can't send between holders
-            mptAlice.pay(bob, carol, 5, tecLOCKED);
-            mptAlice.pay(carol, bob, 6, tecLOCKED);
+            mptAlice.pay(bob, carol, 5, err);
+            mptAlice.pay(carol, bob, 6, err);
             // Issuer can send
             mptAlice.pay(alice, bob, 7);
             // Holder can send back to issuer
@@ -3551,53 +3558,86 @@ class MPToken_test : public beast::unit_test::suite
 
         // Blocking flags
         for (auto flags :
-             {tfMPTCanLock |
-                  tfMPTCanTransfer,  // locked, issuer and holder fails
-              tfMPTRequireAuth |
-                  tfMPTCanTransfer,  // not authorized, holder fails
-              tfMPTCanTrade,         // can't transfer, holder fails
-              tfMPTCanLock})         // lock mptoken, holder fails
+             {tfMPTCanTrade | tfMPTCanLock |
+                  tfMPTCanClawback,  // global lock - holder, issuer fail
+              tfMPTCanTrade |
+                  tfMPTRequireAuth,          // not authorized - holder fails
+              tfMPTCanTrade,                 // holder, issuer succeed
+              tfMPTCanTrade | tfMPTCanLock,  // local lock - holder fails
+              tfMPTCanTransfer})  // can't trade - holder, issuer fail
         {
             Env env{*this, features};
+            env.fund(XRP(1'000), gw, alice);
+            env.close();
 
-            MPTTester mpt(env, gw, {.holders = {alice}});
-
+            // Use CanClawback flag to distinguish global from local lock
             bool const lockMPToken =
-                (flags & (tfMPTCanLock | tfMPTCanTransfer)) == tfMPTCanLock;
+                (flags & (tfMPTCanLock | tfMPTCanClawback)) == tfMPTCanLock;
             bool const lockMPTIssue =
-                (flags & (tfMPTCanLock | tfMPTCanTransfer)) ==
-                (tfMPTCanLock | tfMPTCanTransfer);
+                (flags & (tfMPTCanLock | tfMPTCanClawback)) ==
+                (tfMPTCanLock | tfMPTCanClawback);
             bool const requireAuth = flags & tfMPTRequireAuth;
-            flags = lockMPToken ? (flags | tfMPTCanTransfer) : flags;
 
-            mpt.create({.ownerCount = 1, .holderCount = 0, .flags = flags});
-            auto const MPT = mpt["MPT"];
+            auto mpt = MPTTester(
+                {.env = env,
+                 .issuer = gw,
+                 .holders = {alice},
+                 .pay = 1'000,
+                 .flags = flags,
+                 .authHolder = true});
+            MPT const BTC = mpt;
 
-            if (!requireAuth)
-            {
-                mpt.authorize({.account = alice});
-                mpt.pay(gw, alice, 200);
-            }
+            if (requireAuth)
+                mpt.authorize(
+                    {.account = gw,
+                     .holder = alice,
+                     .flags = tfMPTUnauthorize});
             if (lockMPToken)
                 mpt.set({.holder = alice, .flags = tfMPTLock});
             else if (lockMPTIssue)
                 mpt.set({.flags = tfMPTLock});
 
-            auto const err = [&]() {
-                // Global lock
-                if (lockMPTIssue)
-                    return tecFROZEN;
-                // Local lock
-                else if (lockMPToken)
-                    return tecLOCKED;
-                // MPToken doesn't exist
-                else if (requireAuth)
-                    return tecUNFUNDED_OFFER;
-                return tecNO_PERMISSION;
-            }();
+            auto testOffer = [&](Account const& account,
+                                 auto const& buy,
+                                 auto const& sell,
+                                 bool buyUSD) {
+                auto error = [&](auto const err) -> TER {
+                    if (account == gw)
+                        return tesSUCCESS;
+                    return err;
+                };
+                auto const [errBuy, errSell] = [&]() -> std::pair<TER, TER> {
+                    // Global lock
+                    if (lockMPTIssue)
+                        return std::make_pair(tecFROZEN, tecFROZEN);
+                    // Local lock
+                    if (lockMPToken)
+                        return std::make_pair(
+                            tesSUCCESS, error(tecUNFUNDED_OFFER));
+                    // MPToken doesn't exist
+                    if (requireAuth)
+                        return std::make_pair(
+                            error(tecNO_AUTH), error(tecUNFUNDED_OFFER));
+                    if (flags & tfMPTCanTransfer)
+                        return std::make_pair(
+                            tecNO_PERMISSION, tecNO_PERMISSION);
+                    return std::make_pair(tesSUCCESS, tesSUCCESS);
+                }();
 
-            env(offer(alice, XRP(100), MPT(101)), ter(err));
-            env.close();
+                auto const err = buyUSD ? errBuy : errSell;
+
+                auto seq(env.seq(account));
+                env(offer(account, buy(10), sell(10)), ter(err));
+                env(offer_cancel(account, seq));
+                env.close();
+            };
+
+            auto testOffers = [&](Account const& account) {
+                testOffer(account, XRP, BTC, false);
+                testOffer(account, BTC, XRP, true);
+            };
+            testOffers(alice);
+            testOffers(gw);
         }
 
         // MPTokenV2 is disabled
@@ -3623,7 +3663,7 @@ class MPToken_test : public beast::unit_test::suite
             MPT const BTC = MPT(gw, 0);
             MPT const ETH = MPT(gw, 1);
 
-            env(offer(alice, ETH(10), BTC(10)), ter(tecOBJECT_NOT_FOUND));
+            env(offer(alice, ETH(10), BTC(10)), ter(tecUNFUNDED_OFFER));
         }
 
         // MPToken object doesn't exist and the account is not the issuer of MPT
@@ -3636,7 +3676,7 @@ class MPToken_test : public beast::unit_test::suite
             env(offer(alice, ETH(10), BTC(10)), ter(tecUNFUNDED_OFFER));
         }
 
-        // MPTLocked flag is set and the account is not the issuer of MPT
+        // MPTLock flag is set and the account is not the issuer of MPT
         {
             Account const bob = Account("bob");
             Account const dan = Account("dan");
@@ -3658,16 +3698,31 @@ class MPToken_test : public beast::unit_test::suite
             env(offer(bob, ETH(10), BTC(10)), txflags(tfPassive));
             env(offer(dan, BTC(10), ETH(10)), txflags(tfPassive));
 
-            auto test = [&](auto const& flag, auto const& err) {
+            auto test = [&](auto const& flag, bool gwOwner = false) {
                 BTC.set({.holder = carol, .flags = flag});
                 BTC.set({.holder = alice, .flags = flag});
 
-                env(offer(alice, ETH(1), BTC(1)), err);
-                env(offer(carol, BTC(1), ETH(1)), err);
+                if (gwOwner)
+                {
+                    // Succeeds if the account is the issuer
+                    env(offer(gw, ETH(1), BTC(1)));
+                    env(offer(gw, BTC(1), ETH(1)));
+                }
+                else
+                {
+                    auto const err = flag == tfMPTLock ? ter(tecUNFUNDED_OFFER)
+                                                       : ter(tesSUCCESS);
+                    env(offer(alice, ETH(1), BTC(1)), err);
+                    // Offer created by not crossed
+                    env(offer(carol, BTC(1), ETH(1)));
+                    BEAST_EXPECT(
+                        expectOffers(env, carol, 1, {{BTC(1), ETH(1)}}));
+                }
             };
 
-            test(tfMPTLock, ter(tecLOCKED));
-            test(tfMPTUnlock, ter(tesSUCCESS));
+            test(tfMPTLock);
+            test(tfMPTLock, true);
+            test(tfMPTUnlock);
         }
 
         // MPTRequireAuth flag is set and the account is not authorized
@@ -3693,6 +3748,11 @@ class MPToken_test : public beast::unit_test::suite
                 {.account = gw, .holder = alice, .flags = tfMPTUnauthorize});
 
             env(offer(alice, ETH(10), BTC(10)), ter(tecUNFUNDED_OFFER));
+
+            // issuer can create
+
+            env(offer(gw, ETH(10), BTC(10)));
+            env.close();
         }
 
         // MPTCanTransfer is not set and the account is not the issuer of MPT
@@ -3704,15 +3764,27 @@ class MPToken_test : public beast::unit_test::suite
                  .issuer = gw,
                  .holders = {alice},
                  .pay = 100,
-                 .flags = tfMPTCanTrade});
+                 .flags = tfMPTCanTrade,
+                 .mutableFlags = tmfMPTCanMutateCanTransfer});
             MPTTester ETH(
                 {.env = env,
                  .issuer = gw,
                  .holders = {alice},
                  .pay = 100,
-                 .flags = tfMPTCanTrade});
+                 .flags = tfMPTCanTrade | tfMPTCanTransfer,
+                 .mutableFlags = tmfMPTCanMutateCanTransfer});
 
-            env(offer(alice, ETH(10), BTC(10)), ter(tecNO_PERMISSION));
+            // Can create
+            env(offer(alice, ETH(10), BTC(10)), ter(tesSUCCESS));
+            BTC.set({.mutableFlags = tmfMPTSetCanTransfer});
+            ETH.set({.mutableFlags = tmfMPTClearCanTransfer});
+            env(offer(alice, ETH(10), BTC(10)), ter(tesSUCCESS));
+            BEAST_EXPECT(getAccountOffers(env, alice)[jss::offers].size() == 2);
+
+            // issuer can create
+
+            env(offer(gw, ETH(10), BTC(10)));
+            env.close();
         }
 
         // XRP/MPT
@@ -3951,6 +4023,286 @@ class MPToken_test : public beast::unit_test::suite
                 ter(temMALFORMED));
         }
 
+        {
+            auto const ed = Account{"ed"};
+            Env env{*this, features};
+            env.fund(XRP(1'000), gw, alice, carol, bob, ed);
+            MPTTester BTC(
+                {.env = env,
+                 .issuer = gw,
+                 .holders = {alice, carol, bob},
+                 .pay = 1'000,
+                 .flags = tfMPTCanLock | MPTDEXFlags,
+                 .mutableFlags = tmfMPTCanMutateRequireAuth |
+                     tmfMPTCanMutateCanTrade | tmfMPTCanMutateCanTransfer});
+            MPTTester ETH(
+                {.env = env,
+                 .issuer = gw,
+                 .holders = {alice, carol, bob},
+                 .pay = 1'000,
+                 .flags = tfMPTCanLock | MPTDEXFlags,
+                 .mutableFlags = tmfMPTCanMutateCanTransfer});
+            MPTTester USD(
+                {.env = env,
+                 .issuer = gw,
+                 .holders = {alice, carol, bob},
+                 .pay = 1'000,
+                 .flags = MPTDEXFlags | tfMPTCanLock,
+                 .mutableFlags = tmfMPTCanMutateCanTransfer});
+            MPTTester CAD(
+                {.env = env,
+                 .issuer = gw,
+                 .holders = {alice, carol, bob},
+                 .pay = 1'000,
+                 .flags = MPTDEXFlags | tfMPTCanLock,
+                 .mutableFlags = tmfMPTCanMutateCanTransfer});
+
+            env(offer(bob, ETH(1'000), BTC(1'000)), txflags(tfPassive));
+            env.close();
+            env(offer(bob, BTC(1'000), ETH(1'000)), txflags(tfPassive));
+            env.close();
+
+            // MPTokenIssuance doesn't exist
+
+            env(pay(alice, carol, MPT(gw, 1'000)(10)),
+                sendmax(ETH(10)),
+                ter(tecOBJECT_NOT_FOUND));
+            env.close();
+
+            // MPToken object doesn't exist
+
+            env(pay(ed, carol, BTC(10)), sendmax(ETH(10)), ter(tecNO_AUTH));
+            env(pay(carol, ed, BTC(10)), sendmax(ETH(10)), ter(tecNO_AUTH));
+            env.close();
+
+            // MPTRequireAuth is set
+
+            BTC.authorize({.account = ed});
+            ETH.authorize({.account = ed});
+            env(pay(gw, ed, ETH(100)));
+            env(pay(gw, ed, BTC(100)));
+            env.close();
+            BTC.set({.mutableFlags = tmfMPTSetRequireAuth});
+            // authorize bob to enable the offers trading
+            BTC.authorize({.account = gw, .holder = bob});
+            env.close();
+            env(pay(ed, carol, BTC(10)),
+                path(~BTC),
+                sendmax(ETH(10)),
+                ter(tecNO_AUTH));
+            env(pay(carol, ed, BTC(10)),
+                path(~BTC),
+                sendmax(ETH(10)),
+                ter(tecNO_AUTH));
+            // BTC is transferred from bob to ed, ed is not authorized
+            env(pay(gw, ed, BTC(10)),
+                path(~BTC),
+                sendmax(ETH(10)),
+                ter(tecNO_AUTH));
+            // BTC is transferred from bob to issuer
+            env(pay(ed, gw, BTC(10)), path(~BTC), sendmax(ETH(10)));
+            // BTC is transferred from issuer to bob
+            env(pay(gw, ed, ETH(10)), path(~ETH), sendmax(BTC(10)));
+            // BTC is transferred from ed to bob, ed is not authorized
+            env(pay(ed, gw, ETH(10)),
+                path(~ETH),
+                sendmax(BTC(10)),
+                ter(tecNO_AUTH));
+            env.close();
+            BTC.set({.mutableFlags = tmfMPTClearRequireAuth});
+
+            // MPTCanTransfer is not set
+
+            // Fail regardless if source/destinaiton is the issuer or
+            // not since the offer is owned by a holder.
+            BTC.set({.mutableFlags = tmfMPTClearCanTransfer});
+            env(pay(ed, carol, BTC(10)),
+                path(~BTC),
+                sendmax(ETH(10)),
+                ter(tecPATH_PARTIAL));
+            env(pay(carol, ed, BTC(10)),
+                path(~BTC),
+                sendmax(ETH(10)),
+                ter(tecPATH_PARTIAL));
+            env(pay(ed, carol, ETH(10)),
+                path(~ETH),
+                sendmax(BTC(10)),
+                ter(tecPATH_PARTIAL));
+            env(pay(carol, ed, ETH(10)),
+                path(~ETH),
+                sendmax(BTC(10)),
+                ter(tecPATH_PARTIAL));
+            // Fail because BTC, which has CanTransfer disabled, is sent to
+            // bob
+            env(pay(ed, gw, ETH(10)),
+                path(~ETH),
+                sendmax(BTC(10)),
+                ter(tecPATH_PARTIAL));
+            env(pay(ed, gw, BTC(10)),
+                path(~BTC),
+                sendmax(ETH(10)),
+                ter(tesSUCCESS));
+            env(pay(gw, ed, ETH(10)),
+                path(~ETH),
+                sendmax(BTC(10)),
+                ter(tesSUCCESS));
+            // Fail because BTC, which has CanTransfer disabled, is sent to
+            // ed
+            env(pay(gw, ed, BTC(10)),
+                path(~BTC),
+                sendmax(ETH(10)),
+                ter(tecPATH_PARTIAL));
+            env.close();
+            env(offer(gw, ETH(100), BTC(100)), txflags(tfPassive));
+            env.close();
+            env(offer(gw, BTC(100), ETH(100)), txflags(tfPassive));
+            env.close();
+            env(pay(ed, carol, BTC(10)),
+                path(~BTC),
+                sendmax(ETH(10)),
+                ter(tesSUCCESS));
+            env(pay(ed, carol, ETH(10)),
+                path(~ETH),
+                sendmax(BTC(10)),
+                ter(tesSUCCESS));
+            env(pay(gw, carol, BTC(10)),
+                path(~BTC),
+                sendmax(ETH(10)),
+                ter(tesSUCCESS));
+            env.close();
+            env(pay(ed, gw, BTC(10)), path(~BTC), sendmax(ETH(10)));
+            env.close();
+        }
+        // Multiple steps: CAD/USD, USD/BTC, BTC/ETH
+        {
+            auto const ed = Account{"ed"};
+            Env env{*this, features};
+            env.fund(XRP(1'000), gw, alice, carol, bob, ed);
+            env.close();
+            MPTTester BTC(
+                {.env = env,
+                 .issuer = gw,
+                 .holders = {alice, carol, bob},
+                 .pay = 1'000,
+                 .flags = tfMPTCanLock | MPTDEXFlags,
+                 .mutableFlags = tmfMPTCanMutateCanTransfer});
+            MPTTester ETH(
+                {.env = env,
+                 .issuer = gw,
+                 .holders = {alice, carol, bob},
+                 .pay = 1'000,
+                 .flags = tfMPTCanLock | MPTDEXFlags,
+                 .mutableFlags = tmfMPTCanMutateCanTransfer});
+            MPTTester USD(
+                {.env = env,
+                 .issuer = gw,
+                 .holders = {alice, carol, bob},
+                 .pay = 1'000,
+                 .flags = MPTDEXFlags | tfMPTCanLock,
+                 .mutableFlags = tmfMPTCanMutateCanTransfer});
+            MPTTester CAD(
+                {.env = env,
+                 .issuer = gw,
+                 .holders = {alice, carol, bob},
+                 .pay = 1'000,
+                 .flags = MPTDEXFlags | tfMPTCanLock,
+                 .mutableFlags = tmfMPTCanMutateCanTransfer});
+            // takerGets can transfer if:
+            //  - CanTransfer is set
+            //  - Offer's owner is an issuer
+            //  - BookStep is the last step, which means strand's destination is
+            //    an issuer
+            // takerPays can transfer if
+            //  - BookStep is the first step, which means strand's source is
+            //    an issuer
+            //  - Offer's owner is an issuer
+            //  - Previous step is BookStep, which transfers per above
+            //  - CanTransfer is set
+            env(offer(bob, CAD(100), USD(100)), txflags(tfPassive));
+            env(offer(bob, USD(100), BTC(100)), txflags(tfPassive));
+            env(offer(bob, BTC(100), ETH(100)), txflags(tfPassive));
+            env.close();
+            BEAST_EXPECT(expectOffers(env, bob, 3));
+            BTC.set({.mutableFlags = tmfMPTSetCanTransfer});
+            USD.set({.mutableFlags = tmfMPTClearCanTransfer});
+            // TakerGets
+            // fail - CAD/USD is owned by bob
+            env(pay(alice, carol, ETH(1)),
+                path(~USD, ~BTC, ~ETH),
+                sendmax(CAD(1)),
+                ter(tecPATH_PARTIAL));
+            auto seq(env.seq(gw));
+            env(offer(gw, USD(1), BTC(1)), txflags(tfPassive));
+            env.close();
+            // fail - CAD/USD is owned by bob
+            env(pay(alice, carol, ETH(1)),
+                path(~USD, ~BTC, ~ETH),
+                sendmax(CAD(1)),
+                ter(tecPATH_PARTIAL));
+            env.close();
+            env(offer_cancel(gw, seq));
+            env(offer(gw, CAD(1), USD(1)), txflags(tfPassive));
+            env.close();
+            BEAST_EXPECT(expectOffers(env, bob, 3));
+            // succeed - CAD/USD is owned by issuer
+            env(pay(alice, carol, ETH(1)),
+                path(~USD, ~BTC, ~ETH),
+                sendmax(CAD(1)));
+            env.close();
+            // bob's CAD/USD is deleted
+            BEAST_EXPECT(expectOffers(env, bob, 2));
+            env(offer(bob, CAD(100), USD(100)), txflags(tfPassive));
+            BEAST_EXPECT(expectOffers(env, gw, 0));
+            USD.set({.mutableFlags = tmfMPTSetCanTransfer});
+            ETH.set({.mutableFlags = tmfMPTClearCanTransfer});
+            // fail - BTC/ETH is owned by bob, destination is carol
+            env(pay(alice, carol, ETH(1)),
+                path(~USD, ~BTC, ~ETH),
+                sendmax(CAD(1)),
+                ter(tecPATH_PARTIAL));
+            env.close();
+            BEAST_EXPECT(expectOffers(env, bob, 3));
+            // succeed - destination is an issuer
+            env(pay(alice, gw, ETH(1)),
+                path(~USD, ~BTC, ~ETH),
+                sendmax(CAD(1)));
+            env.close();
+            BEAST_EXPECT(expectOffers(env, bob, 3));
+            // TakerPays
+            ETH.set({.mutableFlags = tmfMPTSetCanTransfer});
+            CAD.set({.mutableFlags = tmfMPTClearCanTransfer});
+            // fail - CAD/USD is owned by bob, source is alice
+            env(pay(alice, carol, ETH(1)),
+                path(~USD, ~BTC, ~ETH),
+                sendmax(CAD(1)),
+                ter(tecPATH_PARTIAL));
+            // succeed - source is the issuer
+            env(pay(gw, carol, ETH(1)),
+                path(~USD, ~BTC, ~ETH),
+                sendmax(CAD(1)));
+            env.close();
+            env(offer(gw, CAD(1), USD(1)), txflags(tfPassive));
+            env.close();
+            // succeed - CAD/USD is owned by issuer
+            env(pay(alice, carol, ETH(1)),
+                path(~USD, ~BTC, ~ETH),
+                sendmax(CAD(1)));
+            env.close();
+            BEAST_EXPECT(expectOffers(env, gw, 0));
+            BEAST_EXPECT(expectOffers(env, bob, 2));
+            CAD.set({.mutableFlags = tmfMPTSetCanTransfer});
+            BTC.set({.mutableFlags = tmfMPTClearCanTransfer});
+            env(offer(bob, CAD(1), USD(1)), txflags(tfPassive));
+            env(offer(gw, USD(1), BTC(1)), txflags(tfPassive));
+            env.close();
+            // succeed - USD/BTC is owned by issuer
+            env(pay(alice, carol, ETH(1)),
+                path(~USD, ~BTC, ~ETH),
+                sendmax(CAD(1)));
+            env.close();
+            BEAST_EXPECT(expectOffers(env, gw, 0));
+        }
+
         // Holders are locked
         {
             Env env(*this);
@@ -3988,9 +4340,21 @@ class MPToken_test : public beast::unit_test::suite
                     txflags(tfNoRippleDirect),
                     sendmax(ETH(1)),
                     err);
+
+                env(pay(gw, carol, ETH(1)),
+                    path(~(MPT)ETH),
+                    txflags(tfNoRippleDirect),
+                    sendmax(BTC(1)),
+                    err);
+
+                env(pay(alice, gw, BTC(1)),
+                    path(~(MPT)BTC),
+                    txflags(tfNoRippleDirect),
+                    sendmax(ETH(1)),
+                    err);
             };
 
-            test(tfMPTLock, ter(tecLOCKED));
+            test(tfMPTLock, ter(tecPATH_DRY));
             test(tfMPTUnlock, ter(tesSUCCESS));
         }
         {
@@ -5591,8 +5955,59 @@ class MPToken_test : public beast::unit_test::suite
             Env env{*this, features};
             env.fund(XRP(1'000), gw, alice, carol);
             auto BTC = MPTTester({.env = env, .issuer = gw});
+            uint256 const chkId{getCheckIndex(alice, env.seq(alice))};
             env(check::create(alice, carol, BTC(50)));
             env.close();
+
+            // But cashing fails if alice doesn't have MPToken
+            env(check::cash(carol, chkId, BTC(1)), ter(tecPATH_PARTIAL));
+            env.close();
+        }
+
+        // MPTLock is set
+        {
+            Env env{*this, features};
+            env.fund(XRP(1'000), gw, alice, carol);
+            env.close();
+            auto mpt = MPTTester(
+                {.env = env,
+                 .issuer = gw,
+                 .holders = {alice, carol},
+                 .pay = 100,
+                 .flags = MPTDEXFlags | tfMPTCanLock});
+
+            mpt.set({.flags = tfMPTLock});
+
+            // Create Check fails, holder or issuer as destination
+            env(check::create(alice, carol, mpt(10)), ter(tecFROZEN));
+            env.close();
+            env(check::create(gw, carol, mpt(10)), ter(tecFROZEN));
+            env.close();
+
+            mpt.set({.flags = tfMPTUnlock});
+
+            // Create Check succeeds, holder or issuer as destination
+            uint256 const chkIdAlice{getCheckIndex(alice, env.seq(alice))};
+            env(check::create(alice, carol, mpt(10)));
+            env.close();
+            uint256 const chkIdGw{getCheckIndex(gw, env.seq(gw))};
+            env(check::create(gw, carol, mpt(10)));
+            env.close();
+
+            mpt.set({.flags = tfMPTLock});
+
+            // Cash Check fails, holder and issuer
+            env(check::cash(carol, chkIdAlice, mpt(1)), ter(tecPATH_PARTIAL));
+            // tec is different if the source is the issuer (this is consistent
+            // with IOU)
+            env(check::cash(carol, chkIdGw, mpt(2)), ter(tecFROZEN));
+            env.close();
+
+            mpt.set({.flags = tfMPTUnlock});
+
+            // Cash Check succeeds, holder and issuer.
+            env(check::cash(carol, chkIdAlice, mpt(1)));
+            env(check::cash(carol, chkIdGw, mpt(2)));
         }
 
         // MPTRequireAuth flag is set and the account is not authorized.
@@ -5604,53 +6019,81 @@ class MPToken_test : public beast::unit_test::suite
             auto BTC = MPTTester(
                 {.env = env,
                  .issuer = gw,
+                 .holders = {alice, carol},
                  .flags = tfMPTRequireAuth | MPTDEXFlags});
+            uint256 const chkId{getCheckIndex(alice, env.seq(alice))};
             env(check::create(alice, carol, BTC(50)));
+            env.close();
+
+            // Authorize alice
+            BTC.authorize({.account = gw, .holder = alice});
+            env(pay(gw, alice, BTC(100)));
+
+            // carol is still not authorized
+            env(check::cash(carol, chkId, BTC(10)), ter(tecNO_AUTH));
+            env.close();
+
+            // authorize carol, can cash now
+            BTC.authorize({.account = gw, .holder = carol});
+            env(check::cash(carol, chkId, BTC(10)));
             env.close();
         }
 
         // MPTCanTransfer disabled
         {
             Env env{*this, features};
+            env.fund(XRP(1'000), gw, alice, carol);
+            env.close();
 
-            MPTTester mpt(env, gw, {.holders = {alice, carol}});
-            mpt.create(
-                {.ownerCount = 1, .holderCount = 0, .flags = tfMPTCanTrade});
-            auto const MPT = mpt["MPT"];
+            MPTTester mpt(
+                {.env = env,
+                 .issuer = gw,
+                 .holders = {alice, carol},
+                 .flags = tfMPTCanTrade,
+                 .mutableFlags = tmfMPTCanMutateCanTransfer});
 
             // src is issuer
             uint256 checkId{keylet::check(gw, env.seq(gw)).key};
 
             // can create
-            env(check::create(gw, alice, MPT(100)));
+            env(check::create(gw, alice, mpt(100)));
             env.close();
 
             // can cash since source is issuer
-            env(check::cash(alice, checkId, MPT(100)));
+            env(check::cash(alice, checkId, mpt(100)));
             env.close();
 
-            BEAST_EXPECT(mpt.checkMPTokenAmount(alice, 100));
-            BEAST_EXPECT(mpt.checkMPTokenOutstandingAmount(100));
+            BEAST_EXPECT(env.balance(alice, mpt) == mpt(100));
+            BEAST_EXPECT(env.balance(gw, mpt) == mpt(-100));
 
             // dst is issuer
             checkId = keylet::check(alice, env.seq(alice)).key;
 
             // can create
-            env(check::create(alice, gw, MPT(100)));
+            env(check::create(alice, gw, mpt(100)));
             env.close();
 
             // can cash since source is issuer
-            env(check::cash(gw, checkId, MPT(100)));
+            env(check::cash(gw, checkId, mpt(100)));
             env.close();
 
-            BEAST_EXPECT(mpt.checkMPTokenAmount(alice, 0));
-            BEAST_EXPECT(mpt.checkMPTokenOutstandingAmount(0));
+            BEAST_EXPECT(env.balance(alice, mpt) == mpt(0));
+            BEAST_EXPECT(env.balance(gw, mpt) == mpt(0));
 
-            // neither src nor dst is issuer
+            // neither src nor dst is issuer, can still create
             checkId = keylet::check(alice, env.seq(alice)).key;
+            env(check::create(alice, carol, mpt(100)));
+            env.close();
 
-            // can't create
-            env(check::create(alice, carol, MPT(100)), ter(tecNO_PERMISSION));
+            // can't cash
+            env(check::cash(carol, checkId, mpt(10)), ter(tecPATH_PARTIAL));
+            env.close();
+
+            // can cash now
+            mpt.set({.account = gw, .mutableFlags = tmfMPTSetCanTransfer});
+            env(pay(gw, alice, mpt(10)));
+            env.close();
+            env(check::cash(carol, checkId, mpt(10)));
             env.close();
         }
 
@@ -5669,6 +6112,7 @@ class MPToken_test : public beast::unit_test::suite
             env(check::cash(carol, chkId, MPT(alice)(1)), ter(temMALFORMED));
             env.close();
         }
+
         // MPToken object doesn't exist and the account is not the issuer of MPT
         {
             Env env{*this, features};
@@ -5686,6 +6130,7 @@ class MPToken_test : public beast::unit_test::suite
             env(check::cash(carol, chkId, BTC(1)));
             env.close();
         }
+
         // MPTRequireAuth flag is set and the account is not authorized.
         {
             Env env{*this, features};
@@ -5716,12 +6161,12 @@ class MPToken_test : public beast::unit_test::suite
                  .holders = {alice, carol},
                  .flags = tfMPTCanTrade});
             uint256 const chkId{getCheckIndex(alice, env.seq(alice))};
-            // alice can't create since CanTransfer is not set
-            env(check::create(alice, carol, EUR(1)), ter(tecNO_PERMISSION));
+            // alice can create
+            env(check::create(alice, carol, EUR(1)));
             env.close();
 
-            // consequently no check to cash
-            env(check::cash(carol, chkId, EUR(1)), ter(tecNO_ENTRY));
+            // carol can't cash
+            env(check::cash(carol, chkId, EUR(1)), ter(tecPATH_PARTIAL));
             env.close();
 
             // if issuer creates a check then carol can cash since
@@ -5813,7 +6258,7 @@ class MPToken_test : public beast::unit_test::suite
                 ter(temBAD_AMOUNT));
         }
 
-        // MPTLocked flag is set and the account is not the issuer of MPT -
+        // MPTLock flag is set and the account is not the issuer of MPT -
         // can still clawback since the issuer clawbacks
         {
             Env env(*this, features);
@@ -5937,6 +6382,31 @@ class MPToken_test : public beast::unit_test::suite
             amm.deposit(DepositArg{.account = alice, .tokens = 10'000});
             amm::ammClawback(
                 gw, alice, MPTIssue(mpt.issuanceID()), xrpIssue(), MPT(10));
+        }
+
+        // clawback one asset from MPT/MPT AMM. MPToken for another asset
+        // is created for the Liquidity Provider
+        {
+            Env env(*this, features);
+            env.fund(XRP(1'000), gw, alice);
+            auto USD = MPTTester(
+                {.env = env,
+                 .issuer = gw,
+                 .holders = {alice},
+                 .pay = 10'000,
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
+            auto EUR = MPTTester(
+                {.env = env,
+                 .issuer = gw,
+                 .flags = tfMPTCanClawback | MPTDEXFlags});
+            AMM amm(env, gw, USD(1'000), EUR(1'000));
+            amm.deposit({.account = alice, .asset1In = USD(1'000)});
+            // MPToken doesn't exist
+            BEAST_EXPECT(
+                env.le(keylet::mptoken(EUR.issuanceID(), alice)) == nullptr);
+            env(amm::ammClawback(gw, alice, USD, EUR, USD(100)));
+            // MPToken is created
+            BEAST_EXPECT(env.le(keylet::mptoken(EUR.issuanceID(), alice)));
         }
     }
 
@@ -6074,109 +6544,291 @@ class MPToken_test : public beast::unit_test::suite
             BEAST_EXPECT(env.balance(alice, EUR) == EUR(0));
         }
 
-        // Create, asset is locked
         {
             Env env(*this);
+            env.fund(XRP(1'000'000), gw, alice, carol);
 
-            env.fund(XRP(1'000), gw, alice);
-            env.close();
-
-            auto USDM = MPTTester(
+            auto USD = MPTTester(
+                {.env = env,
+                 .issuer = gw,
+                 .flags = tfMPTCanLock | MPTDEXFlags,
+                 .mutableFlags = tmfMPTCanMutateRequireAuth |
+                     tmfMPTCanMutateCanTransfer | tmfMPTCanMutateCanClawback});
+            auto EUR = MPTTester(
                 {.env = env,
                  .issuer = gw,
                  .holders = {alice},
-                 .flags = tfMPTCanLock | MPTDEXFlags});
-            MPT const USD = USDM;
-            MPT const EUR =
-                MPTTester({.env = env, .issuer = gw, .holders = {alice}});
+                 .pay = 1'000'000});
 
-            env(pay(gw, alice, EUR(1'000)));
-            env(pay(gw, alice, USD(1'000)));
+            auto const increment = env.current()->fees().increment;
+            auto const txfee = fee(drops(increment));
+            auto const badMPT = MPT(gw, 1'000);
 
-            USDM.set({.flags = tfMPTLock});
+            auto createDeleteAMM = [&](Account const& lp) {
+                AMM amm(
+                    env,
+                    lp,
+                    USD(1'000),
+                    EUR(1'000),
+                    CreateArg{
+                        .fee = static_cast<std::uint32_t>(increment.value())});
+                amm.withdrawAll(lp);
+                BEAST_EXPECT(!amm.ammExists());
+            };
 
-            AMM amm(env, gw, EUR(1'000), USD(1'000), ter(tecFROZEN));
-        }
+            //
+            // AMMCreate
+            //
 
-        // Single deposit, another asset is locked
-        {
-            Env env(*this);
+            auto createJv = AMM::createjv(alice, badMPT(1'000), EUR(1'000), 0);
 
-            env.fund(XRP(1'000), gw, alice);
+            auto createFail = [&](Account const& account, auto const& err) {
+                createJv[sfAccount] = account.human();
+                env(createJv, txfee, ter(err));
+                env.close();
+            };
+
+            // MPTokenIssuance doesn't exist
+
+            createFail(alice, tecOBJECT_NOT_FOUND);
+
+            // MPToken doesn't exist
+
+            createJv[sfAmount] = STAmount{USD(1'000)}.getJson();
+            createFail(alice, tecNO_AUTH);
+
+            // alice authorizes MPToken, can create
+            USD.authorize({.account = alice});
+            env(pay(gw, alice, USD(1'000'000)), txfee);
             env.close();
+            createDeleteAMM(alice);
 
-            auto USDM = MPTTester(
-                {.env = env,
-                 .issuer = gw,
-                 .holders = {alice},
-                 .flags = tfMPTCanLock | MPTDEXFlags});
-            MPT const USD = USDM;
-            MPT const EUR =
-                MPTTester({.env = env, .issuer = gw, .holders = {alice}});
+            // MPTLock is set
 
-            env(pay(gw, alice, EUR(100)));
+            // alice and issuer can't create
+            USD.set({.flags = tfMPTLock});
+            createFail(alice, tecFROZEN);
+            createFail(gw, tecFROZEN);
 
-            AMM amm(env, gw, EUR(1'000), USD(1'000));
+            // MPTRequireAuth is set
 
-            USDM.set({.flags = tfMPTLock});
+            // alice is not authorized
+            USD.set({.flags = tfMPTUnlock});
+            USD.set({.mutableFlags = tmfMPTSetRequireAuth});
+            createFail(alice, tecNO_AUTH);
+            // issuer can create
+            createDeleteAMM(gw);
 
-            amm.deposit(DepositArg{
-                .account = alice, .asset1In = EUR(100), .err = ter(tecFROZEN)});
-        }
+            // alice is authorized, can create
+            USD.authorize({.account = gw, .holder = alice});
+            createDeleteAMM(alice);
 
-        // Single deposit, another asset is unauthorized
-        {
-            Env env(*this);
+            // MPTCanTransfer is not set
 
-            env.fund(XRP(1'000), gw, alice);
+            USD.set({.mutableFlags = tmfMPTClearRequireAuth});
+            USD.set({.mutableFlags = tmfMPTClearCanTransfer});
+            // alice can't create
+            createFail(alice, tecNO_PERMISSION);
+            // issuer can create
+            createDeleteAMM(gw);
+            USD.set({.mutableFlags = tmfMPTSetCanTransfer});
+            // alice can create
+            createDeleteAMM(alice);
+
+            //
+            // AMMDeposit
+            //
+
+            AMM amm(env, gw, USD(1'000), EUR(1'000));
+
+            // MPTokenIssuance doesn't exist
+
+            amm.deposit(
+                {.account = alice,
+                 .asset1In = badMPT(1),
+                 .asset2In = EUR(1),
+                 .assets = std::make_pair(badMPT, EUR),
+                 .err = ter(terNO_AMM)});
+
+            // MPToken doesn't exist
+
+            amm.deposit(
+                {.account = carol,
+                 .asset1In = USD(1),
+                 .asset2In = EUR(1),
+                 .err = ter(tecNO_AUTH)});
+
+            // MPTLock is set
+
+            USD.set({.flags = tfMPTLock});
+            // alice and issuer can't deposit
+            for (auto const& account : {carol, gw})
+            {
+                amm.deposit(
+                    {.account = account,
+                     .asset1In = USD(1),
+                     .asset2In = EUR(1),
+                     .err = ter(tecFROZEN)});
+                amm.deposit(
+                    {.account = account,
+                     .asset1In = EUR(1),
+                     .assets = std::make_pair(EUR, USD),
+                     .err = ter(tecFROZEN)});
+            }
+            USD.set({.flags = tfMPTUnlock});
+
+            // MPTRequireAuth is set
+
+            // carol authorizes MPToken but is not authorized by the issuer
+            USD.authorize({.account = carol});
+            env(pay(gw, carol, USD(1'000'000)));
+            // carol authorizes EUR
+            EUR.authorize({.account = carol});
+            env(pay(gw, carol, EUR(1'000'000)));
+            USD.set({.mutableFlags = tmfMPTSetRequireAuth});
+            // have to authorize amm account
+            USD.authorize(
+                {.account = gw, .holder = Account{"amm", amm.ammAccount()}});
             env.close();
+            amm.deposit(
+                {.account = carol,
+                 .asset1In = USD(1),
+                 .asset2In = EUR(1),
+                 .err = ter(tecNO_AUTH)});
+            amm.deposit(
+                {.account = carol,
+                 .asset1In = EUR(1),
+                 .assets = std::make_pair(EUR, USD),
+                 .err = ter(tecNO_AUTH)});
+            // issuer can deposit
+            amm.deposit({.account = gw, .tokens = 1'000});
+            // carol is authorized, can deposit
+            USD.authorize({.account = gw, .holder = carol});
+            amm.deposit({.account = carol, .tokens = 1'000});
 
-            auto USDM = MPTTester(
-                {.env = env,
-                 .issuer = gw,
-                 .holders = {alice},
-                 .flags = tfMPTCanLock | MPTDEXFlags});
-            MPT const USD = USDM;
-            MPT const EUR = MPTTester({.env = env, .issuer = gw});
+            // MPTCanTransfer is set
 
-            env(pay(gw, alice, USD(100)));
+            USD.set({.mutableFlags = tmfMPTClearRequireAuth});
+            USD.set({.mutableFlags = tmfMPTClearCanTransfer});
+            // carol can't deposit
+            amm.deposit(
+                {.account = carol,
+                 .asset1In = USD(1),
+                 .asset2In = EUR(1),
+                 .err = ter(tecNO_PERMISSION)});
+            amm.deposit(
+                {.account = carol,
+                 .asset1In = EUR(1),
+                 .assets = std::make_pair(EUR, USD),
+                 .err = ter(tecNO_PERMISSION)});
+            // issuer can deposit
+            amm.deposit({.account = gw, .tokens = 1'000});
+            // carol can deposit
+            USD.set({.mutableFlags = tmfMPTSetCanTransfer});
+            amm.deposit({.account = carol, .tokens = 1'000});
 
-            AMM amm(env, gw, EUR(1'000), USD(1'000));
+            //
+            // AMMWithdraw
+            //
 
-            amm.deposit(DepositArg{
-                .account = alice,
-                .asset1In = EUR(100),
-                .err = ter(tecNO_AUTH)});
-        }
+            // MPTokenIssuance doesn't exist
 
-        // Single withdraw, another asset is locked
-        {
-            Env env(*this);
+            amm.withdraw(WithdrawArg{
+                .account = carol,
+                .asset1Out = badMPT(1),
+                .asset2Out = EUR(1),
+                .assets = std::make_pair(badMPT, EUR),
+                .err = ter(terNO_AMM)});
 
-            env.fund(XRP(1'000), gw, alice);
-            env.close();
+            // MPToken doesn't exist - doesn't apply since MPToken is created
+            // on withdraw in this case
 
-            auto USDM = MPTTester(
-                {.env = env,
-                 .issuer = gw,
-                 .holders = {alice},
-                 .flags = tfMPTCanLock | MPTDEXFlags});
-            MPT const USD = USDM;
-            MPT const EUR =
-                MPTTester({.env = env, .issuer = gw, .holders = {alice}});
+            // MPTLock is set
 
-            env(pay(gw, alice, EUR(1'000)));
-            env(pay(gw, alice, USD(1'000)));
+            USD.set({.flags = tfMPTLock});
+            // carol and issuer can't withdraw
+            for (auto const& account : {carol, gw})
+            {
+                amm.withdraw(
+                    {.account = account,
+                     .asset1Out = USD(1),
+                     .asset2Out = EUR(1),
+                     .err = ter(tecFROZEN)});
+                amm.withdraw(
+                    {.account = account,
+                     .tokens = 1'000,
+                     .err = ter(tecFROZEN)});
+                // can single withdraw another asset
+                amm.withdraw(
+                    {.account = account,
+                     .asset1Out = EUR(1),
+                     .assets = std::make_pair(EUR, USD)});
+            }
+            USD.set({.flags = tfMPTUnlock});
 
-            AMM amm(env, alice, EUR(1'000), USD(1'000));
+            // MPTRequireAuth is set
 
-            USDM.set({.flags = tfMPTLock});
+            USD.set({.mutableFlags = tmfMPTSetRequireAuth});
+            USD.authorize(
+                {.account = gw, .holder = carol, .flags = tfMPTUnauthorize});
+            // carol can't withdraw
+            amm.withdraw(
+                {.account = carol,
+                 .asset1Out = USD(1),
+                 .asset2Out = EUR(1),
+                 .err = ter(tecNO_AUTH)});
+            // can withdraw another asset
+            amm.withdraw(
+                {.account = carol,
+                 .asset1Out = EUR(1),
+                 .assets = std::make_pair(EUR, USD)});
+            // issuer can withdraw
+            amm.withdraw(
+                {.account = gw, .asset1Out = USD(1), .asset2Out = EUR(1)});
+            // carol is authorized, can withdraw
+            USD.authorize({.account = gw, .holder = carol});
+            amm.withdraw(
+                {.account = carol, .asset1Out = USD(1), .asset2Out = EUR(1)});
 
-            amm.withdraw(WithdrawArg{.account = alice, .asset1Out = EUR(100)});
+            // MPTCanTransfer is set
 
-            BEAST_EXPECT(amm.expectBalances(
-                EUR(901), USD(1'000), IOUAmount{948'6832980505138, -13}));
-            BEAST_EXPECT(env.balance(alice, EUR) == EUR(99));
+            USD.set({.mutableFlags = tmfMPTClearRequireAuth});
+            USD.set({.mutableFlags = tmfMPTClearCanTransfer});
+            // carol can't withdraw
+            amm.withdraw(
+                {.account = carol,
+                 .asset1Out = USD(1),
+                 .asset2Out = EUR(1),
+                 .err = ter(tecNO_PERMISSION)});
+            // can withdraw another asset
+            amm.withdraw(
+                {.account = carol,
+                 .asset1Out = EUR(1),
+                 .assets = std::make_pair(EUR, USD)});
+            // issuer can withdraw
+            amm.withdraw(
+                {.account = gw, .asset1Out = USD(1), .asset2Out = EUR(1)});
+            // carol can withdraw
+            USD.set({.mutableFlags = tmfMPTSetCanTransfer});
+            amm.withdraw(
+                {.account = carol, .asset1Out = USD(1), .asset2Out = EUR(1)});
+
+            // MPToken created on withdraw
+
+            // redeem all carol's USD and unauthorize USD
+            amm.withdrawAll(carol);
+            env(pay(carol, gw, env.balance(carol, USD)));
+            USD.authorize({.account = carol, .flags = tfMPTUnauthorize});
+            BEAST_EXPECT(
+                env.le(keylet::mptoken(USD.issuanceID(), carol)) == nullptr);
+            // single-deposit EUR
+            amm.deposit(
+                {.account = carol,
+                 .asset1In = EUR(1'000),
+                 .assets = std::make_pair(EUR, USD)});
+            // withdraw in USD to create MPToken
+            amm.withdraw({.account = carol, .asset1Out = USD(100)});
+            BEAST_EXPECT(env.le(keylet::mptoken(USD.issuanceID(), carol)));
         }
     }
 

--- a/src/test/app/MPToken_test.cpp
+++ b/src/test/app/MPToken_test.cpp
@@ -9,15 +9,15 @@
 #include <test/jtx/trust.h>
 #include <test/jtx/xchain_bridge.h>
 
+#include <xrpld/app/misc/AMMHelpers.h>
+#include <xrpld/app/paths/detail/StepChecks.h>
+
 #include <xrpl/basics/base_uint.h>
 #include <xrpl/beast/utility/Zero.h>
 #include <xrpl/protocol/Feature.h>
 #include <xrpl/protocol/TER.h>
 #include <xrpl/protocol/TxFlags.h>
 #include <xrpl/protocol/jss.h>
-
-#include "xrpld/app/misc/AMMHelpers.h"
-#include "xrpld/app/paths/detail/StepChecks.h"
 
 namespace xrpl {
 namespace test {

--- a/src/test/app/PayStrandMPT_test.cpp
+++ b/src/test/app/PayStrandMPT_test.cpp
@@ -327,19 +327,19 @@ struct PayStrandMPT_test : public beast::unit_test::suite
 
             // Account can't issue payments
             USDM.set({.holder = alice, .flags = tfMPTLock});
-            test(env, USD, std::nullopt, STPath(), tecLOCKED);
+            test(env, USD, std::nullopt, STPath(), terLOCKED);
             USDM.set({.holder = alice, .flags = tfMPTUnlock});
             test(env, USD, std::nullopt, STPath(), tesSUCCESS);
 
             // Account can not issue funds
             USDM.set({.flags = tfMPTLock});
-            test(env, USD, std::nullopt, STPath(), tecLOCKED);
+            test(env, USD, std::nullopt, STPath(), terLOCKED);
             USDM.set({.flags = tfMPTUnlock});
             test(env, USD, std::nullopt, STPath(), tesSUCCESS);
 
             // Account can not receive funds
             USDM.set({.holder = bob, .flags = tfMPTLock});
-            test(env, USD, std::nullopt, STPath(), tecLOCKED);
+            test(env, USD, std::nullopt, STPath(), terLOCKED);
             USDM.set({.holder = bob, .flags = tfMPTUnlock});
             test(env, USD, std::nullopt, STPath(), tesSUCCESS);
         }

--- a/src/test/jtx/AMM.h
+++ b/src/test/jtx/AMM.h
@@ -107,8 +107,8 @@ struct BidArg
 
 struct ClawbackArg
 {
-    std::optional<Account> issuer = std::nullopt;
-    std::optional<Account> holder = std::nullopt;
+    Account issuer;
+    Account holder;
     std::optional<std::pair<Asset, Asset>> assets = std::nullopt;
     std::optional<STAmount> amount = std::nullopt;
     std::optional<std::uint32_t> flags = std::nullopt;

--- a/src/test/jtx/AMM.h
+++ b/src/test/jtx/AMM.h
@@ -105,6 +105,16 @@ struct BidArg
     std::optional<std::pair<Asset, Asset>> assets = std::nullopt;
 };
 
+struct ClawbackArg
+{
+    std::optional<Account> issuer = std::nullopt;
+    std::optional<Account> holder = std::nullopt;
+    std::optional<std::pair<Asset, Asset>> assets = std::nullopt;
+    std::optional<STAmount> amount = std::nullopt;
+    std::optional<std::uint32_t> flags = std::nullopt;
+    std::optional<ter> err = std::nullopt;
+};
+
 /** Convenience class to test AMM functionality.
  */
 class AMM
@@ -329,6 +339,9 @@ public:
 
     Json::Value
     bid(BidArg const& arg);
+
+    void
+    clawback(ClawbackArg const& arg);
 
     AccountID const&
     ammAccount() const

--- a/src/test/jtx/impl/AMM.cpp
+++ b/src/test/jtx/impl/AMM.cpp
@@ -768,15 +768,13 @@ AMM::bid(BidArg const& arg)
 void
 AMM::clawback(ClawbackArg const& arg)
 {
-    Account bad("bad", noAccount());
-    Account const& issuer = arg.issuer ? *arg.issuer : bad;
-    Account const& holder = arg.holder ? *arg.holder : bad;
     auto const& [asset, asset2] = [&]() {
         if (arg.assets)
             return *arg.assets;
         return std::make_pair(asset1_.asset(), asset2_.asset());
     }();
-    auto jv = amm::ammClawback(issuer, holder, asset, asset2, arg.amount);
+    auto jv =
+        amm::ammClawback(arg.issuer, arg.holder, asset, asset2, arg.amount);
     if (arg.flags)
         jv[jss::Flags] = *arg.flags;
     if (fee_ != 0)

--- a/src/test/jtx/impl/AMM.cpp
+++ b/src/test/jtx/impl/AMM.cpp
@@ -766,6 +766,25 @@ AMM::bid(BidArg const& arg)
 }
 
 void
+AMM::clawback(ClawbackArg const& arg)
+{
+    Account bad("bad", noAccount());
+    Account const& issuer = arg.issuer ? *arg.issuer : bad;
+    Account const& holder = arg.holder ? *arg.holder : bad;
+    auto const& [asset, asset2] = [&]() {
+        if (arg.assets)
+            return *arg.assets;
+        return std::make_pair(asset1_.asset(), asset2_.asset());
+    }();
+    auto jv = amm::ammClawback(issuer, holder, asset, asset2, arg.amount);
+    if (arg.flags)
+        jv[jss::Flags] = *arg.flags;
+    if (fee_ != 0)
+        jv[jss::Fee] = std::to_string(fee_);
+    submit(jv, std::nullopt, arg.err);
+}
+
+void
 AMM::submit(
     Json::Value const& jv,
     std::optional<jtx::seq> const& seq,

--- a/src/test/jtx/impl/TestHelpers.cpp
+++ b/src/test/jtx/impl/TestHelpers.cpp
@@ -398,7 +398,8 @@ expectOffers(
             }
             return true;
         });
-    return size == cnt && matched == toMatch.size();
+    return size == cnt &&
+        ((toMatch.size() == 0 && size != 0) || (matched == toMatch.size()));
 }
 
 Json::Value

--- a/src/test/jtx/impl/mpt.cpp
+++ b/src/test/jtx/impl/mpt.cpp
@@ -89,12 +89,14 @@ makeMPTCreate(MPTInitDef const& arg)
             .transferFee = arg.transferFee,
             .pay = {{arg.holders, *arg.pay}},
             .flags = arg.flags,
+            .mutableFlags = arg.mutableFlags,
             .authHolder = arg.authHolder};
     return {
         .maxAmt = arg.maxAmt,
         .transferFee = arg.transferFee,
         .authorize = arg.holders,
         .flags = arg.flags,
+        .mutableFlags = arg.mutableFlags,
         .authHolder = arg.authHolder};
 }
 

--- a/src/test/jtx/mpt.h
+++ b/src/test/jtx/mpt.h
@@ -116,6 +116,7 @@ struct MPTInitDef
     std::uint16_t transferFee = 0;
     std::optional<std::uint64_t> pay = std::nullopt;
     std::uint32_t flags = MPTDEXFlags;
+    std::optional<std::uint32_t> mutableFlags = std::nullopt;
     bool authHolder = false;
     bool fund = false;
     bool close = true;
@@ -280,7 +281,7 @@ public:
     friend BookSpec
     operator~(MPTTester const& mpt)
     {
-        return ~MPT();
+        return ~(MPT)mpt;
     }
 
 private:

--- a/src/test/jtx/mpt.h
+++ b/src/test/jtx/mpt.h
@@ -281,7 +281,7 @@ public:
     friend BookSpec
     operator~(MPTTester const& mpt)
     {
-        return ~(MPT)mpt;
+        return ~static_cast<MPT>(mpt);
     }
 
 private:

--- a/src/xrpld/app/misc/MPTUtils.h
+++ b/src/xrpld/app/misc/MPTUtils.h
@@ -23,15 +23,7 @@ checkMPTTxAllowed(
     ReadView const& v,
     TxType tx,
     Asset const& asset,
-    AccountID const& accountID,
-    std::optional<AccountID> const& destAccount = std::nullopt);
-
-TER
-checkMPTDEXAllowed(
-    ReadView const& view,
-    Asset const& issuanceID,
-    AccountID const& srcAccount,
-    std::optional<AccountID> const& destAccount);
+    AccountID const& accountID);
 
 inline std::int64_t
 maxMPTAmount(SLE const& sleIssuance)

--- a/src/xrpld/app/misc/detail/MPTUtils.cpp
+++ b/src/xrpld/app/misc/detail/MPTUtils.cpp
@@ -11,18 +11,16 @@ checkMPTAllowed(
     ReadView const& view,
     TxType txType,
     Asset const& asset,
-    AccountID const& accountID,
-    std::optional<AccountID> const& destAccount)
+    AccountID const& accountID)
 {
     if (!asset.holds<MPTIssue>())
         return tesSUCCESS;
 
     auto const& issuanceID = asset.get<MPTIssue>().getMptID();
-    auto const isDEX = txType == ttPAYMENT && destAccount;
     auto const validTx = txType == ttAMM_CREATE || txType == ttAMM_DEPOSIT ||
         txType == ttAMM_WITHDRAW || txType == ttOFFER_CREATE ||
         txType == ttCHECK_CREATE || txType == ttCHECK_CASH ||
-        txType == ttPAYMENT || isDEX;
+        txType == ttPAYMENT;
     XRPL_ASSERT(validTx, "xrpl::checkMPTAllowed : all MPT tx or DEX");
     if (!validTx)
         return tefINTERNAL;
@@ -41,13 +39,12 @@ checkMPTAllowed(
     if (flags & lsfMPTLocked)
         return tecLOCKED;
     // Offer crossing and Payment
-    if ((flags & lsfMPTCanTrade) == 0 && isDEX)
+    if ((flags & lsfMPTCanTrade) == 0)
         return tecNO_PERMISSION;
 
     if (accountID != issuer)
     {
-        if ((flags & lsfMPTCanTransfer) == 0 &&
-            (!destAccount || destAccount != issuer))
+        if ((flags & lsfMPTCanTransfer) == 0)
             return tecNO_PERMISSION;
 
         auto const mptSle =
@@ -57,8 +54,7 @@ checkMPTAllowed(
         if (!mptSle)
             return tesSUCCESS;
 
-        if ((mptSle->getFlags() & lsfMPTLocked) &&
-            (!destAccount || destAccount != issuer))
+        if (mptSle->getFlags() & lsfMPTLocked)
             return tecLOCKED;
     }
 
@@ -70,23 +66,11 @@ checkMPTTxAllowed(
     ReadView const& view,
     TxType txType,
     Asset const& asset,
-    AccountID const& accountID,
-    std::optional<AccountID> const& destAccount)
+    AccountID const& accountID)
 {
     // use isDEXAllowed for payment/offer crossing
     XRPL_ASSERT(txType != ttPAYMENT, "xrpl::checkMPTTxAllowed : not payment");
-    return checkMPTAllowed(view, txType, asset, accountID, destAccount);
-}
-
-TER
-checkMPTDEXAllowed(
-    ReadView const& view,
-    Asset const& asset,
-    AccountID const& accountID,
-    std::optional<AccountID> const& dest)
-{
-    // use ttPAYMENT for any DEX transaction
-    return checkMPTAllowed(view, ttPAYMENT, asset, accountID, dest);
+    return checkMPTAllowed(view, txType, asset, accountID);
 }
 
 }  // namespace xrpl

--- a/src/xrpld/app/paths/detail/BookStep.cpp
+++ b/src/xrpld/app/paths/detail/BookStep.cpp
@@ -52,6 +52,7 @@ protected:
     // quality or there is no CLOB offer.
     std::optional<AMMLiquidity<TIn, TOut>> ammLiquidity_;
     beast::Journal const j_;
+    Asset const strandDeliver_;
 
     struct Cache
     {
@@ -73,6 +74,7 @@ public:
         , prevStep_(ctx.prevStep)
         , ownerPaysTransferFee_(ctx.ownerPaysTransferFee)
         , j_(ctx.j)
+        , strandDeliver_(ctx.strandDeliver)
     {
         if (auto const ammSle = ctx.view.read(keylet::amm(in, out));
             ammSle && ammSle->getFieldAmount(sfLPTokenBalance) != beast::zero)
@@ -235,6 +237,11 @@ private:
     // whichever is a better quality.
     std::optional<QualityFunction>
     tipOfferQualityF(ReadView const& view) const;
+
+    // Check that takerPays/takerGets can be transferred/traded.
+    // Applies to MPT assets.
+    bool
+    checkMPTDEX(ReadView const& view, AccountID const& owner) const;
 };
 
 //------------------------------------------------------------------------------
@@ -722,9 +729,7 @@ BookStep<TIn, TOut, TDerived>::forEachOffer(
             return true;
 
         Asset const& assetIn = offer.assetIn();
-        Asset const& assetOut = offer.assetOut();
         bool const isAssetInMPT = assetIn.holds<MPTIssue>();
-        bool const isAssetOutMPT = assetOut.holds<MPTIssue>();
         auto const& owner = offer.owner();
 
         if (isAssetInMPT)
@@ -742,15 +747,10 @@ BookStep<TIn, TOut, TDerived>::forEachOffer(
         // or afView. Amendment guard this change just in case.
         auto& applyView = sb.rules().enabled(featureMPTokensV2) ? sb : afView;
         // Make sure offer owner has authorization to own Assets from issuer
-        // if IOU. An account can always own XRP or their own Assets.
-        // If MPT then MPTDEX should be allowed.
+        // and MPT assets can be traded/transferred.
+        // An account can always own XRP or their own Assets.
         if (requireAuth(applyView, assetIn, owner) != tesSUCCESS ||
-            (isAssetInMPT &&
-             checkMPTDEXAllowed(applyView, assetIn, owner, std::nullopt) !=
-                 tesSUCCESS) ||
-            (isAssetOutMPT &&
-             checkMPTDEXAllowed(applyView, assetOut, owner, std::nullopt) !=
-                 tesSUCCESS))
+            !checkMPTDEX(sb, owner))
         {
             // Offer owner not authorized to hold IOU/MPT from issuer.
             // Remove this offer even if no crossing occurs.
@@ -1362,7 +1362,7 @@ BookStep<TIn, TOut, TDerived>::check(StrandContext const& ctx) const
 
     auto issuerExists = [](ReadView const& view, Asset const& iss) -> bool {
         return isXRP(iss.getIssuer()) ||
-            view.read(keylet::account(iss.getIssuer()));
+            view.exists(keylet::account(iss.getIssuer()));
     };
 
     if (!issuerExists(ctx.view, book_.in) || !issuerExists(ctx.view, book_.out))
@@ -1390,16 +1390,11 @@ BookStep<TIn, TOut, TDerived>::check(StrandContext const& ctx) const
                     return std::nullopt;
                 },
                 [&](MPTIssue const& issue) -> std::optional<TER> {
-                    auto const issuanceID =
-                        keylet::mptIssuance(issue.getMptID());
-                    if (!view.exists(issuanceID))
-                        return tecOBJECT_NOT_FOUND;
-
-                    if (auto const ter = checkMPTDEXAllowed(
-                            view,
-                            book_.in,
-                            issue.getIssuer(),
-                            issue.getIssuer());
+                    // Check if can trade on DEX.
+                    if (auto const ter = canTrade(view, book_.in);
+                        ter != tesSUCCESS)
+                        return ter;
+                    if (auto const ter = canTrade(view, book_.out);
                         ter != tesSUCCESS)
                         return ter;
                     return std::nullopt;
@@ -1429,6 +1424,55 @@ BookStep<TIn, TOut, TDerived>::rate(
             return transferRate(view, issue.getMptID());
         });
 };
+
+template <class TIn, class TOut, class TDerived>
+bool
+BookStep<TIn, TOut, TDerived>::checkMPTDEX(
+    ReadView const& view,
+    AccountID const& owner) const
+{
+    if (canTrade(view, book_.in) != tesSUCCESS ||
+        canTrade(view, book_.out) != tesSUCCESS)
+        return false;
+
+    if (book_.in.holds<MPTIssue>())
+    {
+        auto ret = [&]() {
+            auto const& asset = book_.in;
+            // Strand's source is an issuer
+            if (!prevStep_)
+                return true;
+            // Offer's owner is an issuer
+            if (asset.getIssuer() == owner)
+                return true;
+            // Previous step is BookStep. BookStep only sends if CanTransfer is
+            // set and not locked or the offer is owned by an issuer
+            if (prevStep_->bookStepBook())
+                return true;
+            // Previous step is MPTEndpointStep and offer's owner is not an
+            // issuer
+            return canTransfer(view, asset, owner, owner) == tesSUCCESS;
+        }();
+        if (!ret)
+            return false;
+    }
+
+    if (book_.out.holds<MPTIssue>())
+    {
+        auto const& asset = book_.out;
+        // Last step if the strand's destination is an issuer
+        if (strandDeliver_ == asset && strandDst_ == asset.getIssuer())
+            return true;
+        // Offer's owner is an issuer
+        if (asset.getIssuer() == owner)
+            return true;
+
+        // Next step is BookStep and offer's owner is not an issuer
+        return canTransfer(view, asset, owner, owner) == tesSUCCESS;
+    }
+
+    return true;
+}
 
 //------------------------------------------------------------------------------
 

--- a/src/xrpld/app/paths/detail/MPTEndpointStep.cpp
+++ b/src/xrpld/app/paths/detail/MPTEndpointStep.cpp
@@ -347,22 +347,8 @@ MPTEndpointPaymentStep::check(
     // Cross-token MPT payment via DEX
     else
     {
-        if (ctx.isFirst && src_ != mptIssue_.getIssuer())
-        {
-            if (auto const ter =
-                    checkMPTDEXAllowed(ctx.view, mptIssue_, src_, std::nullopt);
-                ter != tesSUCCESS)
-                return ter;
-        }
-        else if (
-            ctx.prevStep && ctx.prevStep->bookStepBook() &&
-            dst_ != mptIssue_.getIssuer())
-        {
-            if (auto const ter =
-                    checkMPTDEXAllowed(ctx.view, mptIssue_, dst_, std::nullopt);
-                ter != tesSUCCESS)
-                return ter;
-        }
+        if (auto const ter = canTrade(ctx.view, mptIssue_); ter != tesSUCCESS)
+            return ter;
     }
 
     // Can't check for creditBalance/Limit unless it's the first step.
@@ -387,15 +373,6 @@ MPTEndpointOfferCrossingStep::check(
     StrandContext const& ctx,
     std::shared_ptr<const SLE> const&) const
 {
-    auto const& holder = ctx.isFirst ? src_ : dst_;
-    auto const& issuer = mptIssue_.getIssuer();
-    if (holder != issuer)
-    {
-        if (auto const ter =
-                checkMPTDEXAllowed(ctx.view, mptIssue_, holder, issuer);
-            ter != tesSUCCESS)
-            return ter;
-    }
     return tesSUCCESS;
 }
 
@@ -877,6 +854,14 @@ MPTEndpointStep<TDerived>::check(StrandContext const& ctx) const
             << "MPTEndpointStep: can't receive MPT from non-existent issuer: "
             << src_;
         return terNO_ACCOUNT;
+    }
+
+    // pure issue/redeem can't be frozen (issuer/holder)
+    if (!(ctx.isLast && ctx.isFirst))
+    {
+        auto const& account = ctx.isFirst ? src_ : dst_;
+        if (isFrozen(ctx.view, account, mptIssue_))
+            return terLOCKED;
     }
 
     if (ctx.seenBookOuts.count(mptIssue_))

--- a/src/xrpld/app/tx/detail/CashCheck.cpp
+++ b/src/xrpld/app/tx/detail/CashCheck.cpp
@@ -258,8 +258,7 @@ CashCheck::preclaim(PreclaimContext const& ctx)
                         return tecFROZEN;
                     }
 
-                    if (auto const err = checkMPTDEXAllowed(
-                            ctx.view, value.asset(), srcId, dstId);
+                    if (auto const err = canTrade(ctx.view, value.asset());
                         err != tesSUCCESS)
                     {
                         JLOG(ctx.j.warn()) << "MPT DEX is not allowed.";

--- a/src/xrpld/app/tx/detail/CreateCheck.cpp
+++ b/src/xrpld/app/tx/detail/CreateCheck.cpp
@@ -160,12 +160,7 @@ CreateCheck::preclaim(PreclaimContext const& ctx)
         return tecEXPIRED;
     }
 
-    if (auto const ter = checkMPTTxAllowed(
-            ctx.view, ttCHECK_CREATE, ctx.tx[sfSendMax].asset(), srcId, dstId);
-        ter != tesSUCCESS)
-        return ter;
-
-    return tesSUCCESS;
+    return canTrade(ctx.view, ctx.tx[sfSendMax].asset());
 }
 
 TER

--- a/src/xrpld/app/tx/detail/CreateOffer.cpp
+++ b/src/xrpld/app/tx/detail/CreateOffer.cpp
@@ -157,15 +157,6 @@ CreateOffer::preclaim(PreclaimContext const& ctx)
         return tecFROZEN;
     }
 
-    if (auto const ter =
-            checkMPTDEXAllowed(ctx.view, saTakerPays.asset(), id, std::nullopt);
-        ter != tesSUCCESS)
-        return ter;
-    if (auto const ter =
-            checkMPTDEXAllowed(ctx.view, saTakerGets.asset(), id, std::nullopt);
-        ter != tesSUCCESS)
-        return ter;
-
     // Allow unfunded MPT for issuer (OutstandingAmount >= MaximumAmount)
     if ((!saTakerGets.holds<MPTIssue>() || saTakerGets.getIssuer() != id) &&
         accountFunds(
@@ -214,6 +205,13 @@ CreateOffer::preclaim(PreclaimContext const& ctx)
                 ctx.view, id, ctx.tx[sfDomainID]))
             return tecNO_PERMISSION;
     }
+
+    if (auto const ter = canTrade(ctx.view, saTakerPays.asset());
+        ter != tesSUCCESS)
+        return ter;
+    if (auto const ter = canTrade(ctx.view, saTakerGets.asset());
+        ter != tesSUCCESS)
+        return ter;
 
     return tesSUCCESS;
 }


### PR DESCRIPTION
Enforce CanTrade enabled for all MPT supporting transactions.

* Replace checkMPTDEX() with canTrade().
* Update CanTrade/CanTransfer rules
* Extend the unit-tests

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Performance (increase or change in throughput and/or latency)
- [ ] Tests (you added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation update
- [ ] Chore (no impact to binary, e.g. `.gitignore`, formatting, dropping support for older tooling)
- [ ] Release

## Test Plan

Extend unit-tests